### PR TITLE
Add PSModuleNuget DependencyType

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nuget.exe

--- a/PSDepend/PSDepend.NugetPath
+++ b/PSDepend/PSDepend.NugetPath
@@ -1,0 +1,6 @@
+# You can use the following:
+# Absolute paths
+# Relative paths
+# UNC paths
+# $ModuleRoot as "the path to the PSDepend module folder"
+$ModuleRoot\nuget.exe

--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -16,4 +16,14 @@
         }
     }
 
+
+#Get nuget dependecy file
+    $NuGetPath = Get-Content $ModuleRoot\PSDepend.NugetPath | Where{$_ -notmatch "^\s*#"} | Select -First 1
+    $NugetPath = $NugetPath -replace '\$ModuleRoot', $ModuleRoot
+    $NuGetPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($NuGetPath)
+    If(-not (Test-Path $NuGetPath))
+    {
+        BootStrap-Nuget -NugetPath $NuGetPath
+    }
+
 Export-ModuleMember -Function $Public.Basename

--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -17,13 +17,10 @@
     }
 
 
-#Get nuget dependecy file
+#Get nuget dependecy file if we don't have it
     $NuGetPath = Get-Content $ModuleRoot\PSDepend.NugetPath | Where{$_ -notmatch "^\s*#"} | Select -First 1
     $NugetPath = $NugetPath -replace '\$ModuleRoot', $ModuleRoot
     $NuGetPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($NuGetPath)
-    If(-not (Test-Path $NuGetPath))
-    {
-        BootStrap-Nuget -NugetPath $NuGetPath
-    }
+    BootStrap-Nuget -NugetPath $NuGetPath
 
 Export-ModuleMember -Function $Public.Basename

--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -21,8 +21,15 @@
       Description = 'Install a PowerShell module from the PowerShell Gallery.'
     }
 
+    PSGalleryNuget = @{
+      Script = 'PSGalleryNuget.ps1'
+      Description = 'Install a PowerShell module from the PowerShell Gallery without the PowerShellGet dependency'
+    }
+
     Task = @{
       Script = 'Task.ps1'
       Description = 'Support dependencies by handling simple tasks.'
     }
+
+
 }

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -1,0 +1,139 @@
+<#
+    .SYNOPSIS
+        Installs a module from a PowerShell repository like the PowerShell Gallery using nuget.exe
+
+    .DESCRIPTION
+        Installs a module from a PowerShell repository like the PowerShell Gallery using nuget.exe
+
+        Note that this will remove any existing module from 
+
+        Relevant Dependency metadata:
+            Name: The name for this module
+            Version: Used to identify existing installs meeting this criteria, and as RequiredVersion for installation.  Defaults to 'latest'
+            Source: Source Uri for Nuget.  Defaults to https://www.powershellgallery.com/api/v2/
+            Target: Required path to save this module.  No Default
+                Example: To install PSDeploy to C:\temp\PSDeploy, I would specify C:\temp
+            AddToPath: Add the Target to ENV:PSModulePath
+
+    .PARAMETER Force
+        If specified and Target is specified, create folders if needed
+
+    .PARAMETER Import
+        If specified, import the module in the global scope
+#>
+[cmdletbinding()]
+param(
+    [PSTypeName('PSDepend.Dependency')]
+    [psobject[]]$Dependency,
+
+    [switch]$Force,
+
+    [switch]$ExcludeVersion,
+
+    [switch]$Import
+)
+
+# Extract data from Dependency
+    $DependencyName = $Dependency.DependencyName
+    $Name = $Dependency.Name
+    if(-not $Name)
+    {
+        $Name = $DependencyName
+    }
+
+    $Version = $Dependency.Version
+    if(-not $Version)
+    {
+        $Version = 'latest'
+    }
+
+    $Source = $Dependency.Source
+    if(-not $Dependency.Source)
+    {
+        $Source = 'https://www.powershellgallery.com/api/v2/'
+    }
+
+    # We use target as a proxy for Scope
+    if(-not $Dependency.Target)
+    {
+        Write-Error "PSGalleryNuget requires a Dependency Target. Skipping [$DependencyName]"
+        return
+    }
+
+if(-not (Get-Command Nuget.exe -ErrorAction SilentlyContinue))
+{
+    Write-Error "PSGalleryNuget requires Nuget.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.NugetPath.  Skipping [$DependencyName]"
+}
+
+Write-Verbose -Message "Getting dependency [$name] from Nuget source [$Source]"
+
+$params = @($Name, '-ExcludeVersion', '-Source', $Source, '-OutputDirectory', "$Target")
+
+if( $Version -and $Version -ne 'latest')
+{
+    $Params.add('-Version',$Version)
+}
+
+# This code works for both install and save scenarios.
+$ModulePath =  Join-Path $Target $Name
+
+## BREAK
+
+$Existing = $null
+$Existing = Get-Module -ListAvailable -Name $ModuleName -ErrorAction SilentlyContinue
+
+if($Existing)
+{
+    Write-Verbose "Found existing module [$Name]"
+    # Thanks to Brandon Padgett!
+    $ExistingVersion = $Existing | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum
+    $GalleryVersion = Find-Module -Name $Name -Repository PSGallery | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum
+    
+    # Version string, and equal to current
+    if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)
+    {
+        Write-Verbose "You have the requested version [$Version] of [$Name]"
+        return $null
+    }
+    
+    # latest, and we have latest
+    if( $Version -and
+        ($Version -eq 'latest' -or $Version -like '') -and
+        $GalleryVersion -le $ExistingVersion
+    )
+    {
+        Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
+        return $null
+    }
+
+    Write-Verbose "Continuing to install [$Name]: Requested version [$version], existing version [$ExistingVersion], PSGallery version [$GalleryVersion]"
+}
+
+$ImportParam = @{}
+if('AllUsers', 'CurrentUser' -contains $Scope)
+{   
+    Write-Verbose "Installing [$Name] with scope [$Scope]"
+    Install-Module @params -Scope $Scope
+}
+elseif((Test-Path $Scope -PathType Container) -or $Force)
+{
+    Write-Verbose "Saving [$Name] with path [$Scope]"
+    if($Force)
+    {
+        Write-Verbose "Force creating directory path to [$Scope]"
+        $Null = New-Item -ItemType Directory -Path $Scope -Force -ErrorAction SilentlyContinue
+    }
+    Save-Module @params -Path $Scope
+
+    if($Dependency.AddToPath)
+    {
+        Write-Verbose "Setting PSModulePath to`n$($env:PSModulePath, $Scope -join ';' | Out-String)"
+        $env:PSModulePath = $env:PSModulePath, $Scope -join ';'
+    }
+}
+
+if($Import)
+{
+    Write-Verbose "Importing [$ModuleName]"
+    Import-Module $ModuleName -Scope Global -Force 
+}

--- a/PSDepend/Private/Bootstrap-Nuget.ps1
+++ b/PSDepend/Private/Bootstrap-Nuget.ps1
@@ -1,0 +1,32 @@
+﻿# Check for nuget exe. If it doesn't exist, create full path to parent, and download it
+function BootStrap-Nuget {
+    [cmdletbinding()]
+    param(
+        $NugetPath = "$env:APPDATA\nuget.exe"
+    )
+
+    if($c = Get-Command 'nuget.exe' -ErrorAction SilentlyContinue)
+    {
+        write-verbose "Found Nuget at [$($c.path)]"
+        return
+    }
+
+    #Don't have it, download it
+    $Parent = Split-Path $NugetPath -Parent
+    if(-not (Test-Path $NugetPath))
+    {
+        if(-not (Test-Path $Parent))
+        {
+            Write-Verbose "Creating parent paths to [$NugetPath]'s parent: [$Parent]"
+            mkdir $Parent -Force   
+        }
+        Write-Verbose "Downloading nuget to [$NugetPath]"
+        Invoke-WebRequest -uri 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $NugetPath
+    }
+
+    # Add to path
+    if( ($ENV:Path -split ';') -notcontains $Parent )
+    {
+        $ENV:Path = $ENV:Path, $Parent -join ';'
+    }
+}

--- a/PSDepend/Private/Find-NugetPackage.ps1
+++ b/PSDepend/Private/Find-NugetPackage.ps1
@@ -1,0 +1,42 @@
+﻿# All credit and major props to Joel Bennett for this simplified solution that doesn't depend on PowerShellGet
+# https://gist.github.com/Jaykul/1caf0d6d26380509b04cf4ecef807355
+function Find-NugetPackage {
+    [CmdletBinding()]
+    param(
+        # The name of a package to find
+        [Parameter(Mandatory)]
+        $Name,
+        # The repository api URL -- like https://www.powershellgallery.com/api/v2/ or https://www.nuget.org/api/v2/
+        $PackageSourceUrl = 'https://www.powershellgallery.com/api/v2/',
+
+        #If specified takes precedence over version
+        [switch]$IsLatest,
+
+        [string]$Version
+    )
+
+    #Ugly way to do this.  Prefer islatest, otherwise look for version, otherwise grab all matching modules
+    if($IsLatest)
+    {
+        Write-Verbose "Searching for latest [$name] module"
+        $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name' and IsLatestVersion"
+    }
+    elseif($PSBoundParameters.ContainsKey($Version))
+    {
+        Write-Verbose "Searching for version [$version] of [$name]"
+        $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name' and Version eq '$Version'"
+    }
+    else
+    {
+        Write-Verbose "Searching for all versions of [$name] module"
+        $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name'"
+    }
+
+    Invoke-RestMethod $URI | 
+    Select-Object @{n='Name';ex={$_.title.('#text')}},
+                  @{n='Author';ex={$_.author.name}},
+                  @{n='Version';ex={$_.properties.NormalizedVersion}},
+                  @{n='Uri';ex={$_.Content.src}},
+                  @{n='Description';ex={$_.properties.Description}},
+                  @{n='Properties';ex={$_.properties}}
+}

--- a/PSDepend/Private/Save-NugetPackage.ps1
+++ b/PSDepend/Private/Save-NugetPackage.ps1
@@ -1,0 +1,14 @@
+﻿# All credit and major props to Joel Bennett for this simplified solution that doesn't depend on PowerShellGet
+# https://gist.github.com/Jaykul/1caf0d6d26380509b04cf4ecef807355
+function Save-NugetPackage {
+    [CmdletBinding()]
+    param(
+        [Parameter(ValueFromPipelineByPropertyName,Mandatory)]$Name,
+        [Parameter(ValueFromPipelineByPropertyName,Mandatory)]$Uri,
+        [Parameter(ValueFromPipelineByPropertyName)]$Version="",
+        [string]$Path = $pwd
+    )
+    $Path = (Join-Path $Path "$Name.$Version.nupkg")
+    Invoke-WebRequest $Uri -OutFile $Path
+    Get-Item $Path
+}

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -20,6 +20,7 @@ function Get-Dependency {
             DependsOn      : Dependency that must be installed before this
             PreScripts     : One or more paths to PowerShell scripts to run before the dependency
             PostScripts    : One or more paths to PowerShell scripts to run after the dependency
+            PSDependOptions: Hash table of global PSDepend options
             Raw            : Raw output for this dependency from the PSD1. May include data outside of standard items above.
 
         These are parsed from dependency PSD1 files as follows:
@@ -115,6 +116,14 @@ function Get-Dependency {
             $File = Split-Path $DependencyFile -Leaf
             $Dependencies = Import-LocalizedData -BaseDirectory $Base -FileName $File
 
+
+            $PSDependOptions = $null
+            if($Dependencies.Containskey('PSDependOptions'))
+            {
+                $PSDependOptions = $Dependencies.PSDependOptions
+                $Dependencies.Remove('PSDependOptions')
+            }
+
             foreach($Dependency in $Dependencies.keys)
             {
                 $DependencyHash = $Dependencies.$Dependency
@@ -137,6 +146,7 @@ function Get-Dependency {
                         DependsOn = $null
                         PreScripts = $null
                         PostScripts = $null
+                        PSDependOptions = $PSDependOptions
                         Raw = $null
                     }
                 }
@@ -164,6 +174,7 @@ function Get-Dependency {
                         DependsOn = $DependencyHash.DependsOn
                         PreScripts = $DependencyHash.PreScripts
                         PostScripts = $DependencyHash.PostScripts
+                        PSDependOptions = $PSDependOptions
                         Raw = $DependencyHash
                     }
                 }

--- a/PSDepend/en-US/about_PSDepend.help.txt
+++ b/PSDepend/en-US/about_PSDepend.help.txt
@@ -27,7 +27,19 @@ DETAILED DESCRIPTION
                                 For example, the PSGalleryModule script uses PowerShellGet to find
                                 and install any dependencies specified in a depend.psd1 or requirements.psd1 file.
 
+    Dependencies
+    ============
+    
+    Each dependency type may have certain prerequisites:
 
+      * PSGalleryModule: Requires the PowerShellGet module (WMF 5 or a separate install)
+      * PSGalleryNuget:  This requires nuget.exe in your path*.  We handle this for you:
+                         When you import PSDepend, we... 
+                            Look for nuget.exe in your path. 
+                            If we don't find it... Look in the path specified in PSDepend\PSDepend.NugetPath. Default is PSDepend\nuget.exe
+                                If we don't find it there, we download to that path
+                                If we do find it there, we add the parent container to $ENV:Path 
+                            
     Example use (*.PSDepend.ps1)
     ============================
 


### PR DESCRIPTION
This dependency type does not rely on the PowerShellGet module.

Logic was added to the PSDepend.psm1 to ensure a nuget.exe is available for the dependency type.  It checks for an existing nuget.exe in your path, it checks a configurable path in PSDepend\PSDepend.NuGetPath, downloads to that path if it isn't found, and adds the parent folder to your $ENV:Path.

We currently require a Target to be specified for an installation location.  I'm torn on specifying a default for this, but would be open to it.