### PR TITLE
Add Git dependency type

### DIFF
--- a/PSDepend/PSDepend.Config
+++ b/PSDepend/PSDepend.Config
@@ -3,4 +3,5 @@
 # Relative paths
 # UNC paths
 # $ModuleRoot as "the path to the PSDepend module folder"
-$ModuleRoot\nuget.exe
+NuGetPath=$ModuleRoot\nuget.exe
+GitPath=$ModuleRoot\git\git.exe

--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -18,9 +18,16 @@
 
 
 #Get nuget dependecy file if we don't have it
-    $NuGetPath = Get-Content $ModuleRoot\PSDepend.NugetPath | Where{$_ -notmatch "^\s*#"} | Select -First 1
-    $NugetPath = $NugetPath -replace '\$ModuleRoot', $ModuleRoot
-    $NuGetPath = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($NuGetPath)
+    Get-Content $ModuleRoot\PSDepend.Config |
+        Where{$_ -and $_ -notmatch "^\s*#"} |
+        Foreach {
+            $Name = ( $_ -split '=')[0].trim()
+            $Value = ( $_ -split '=')[1].trim()
+            # Revisit later and only apply these for '*path', if we have other types of variables...
+            $Value = $Value -replace '\$ModuleRoot', $ModuleRoot
+            $Value = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Value)
+            Set-Variable -Name $Name -Value $Value
+        }
     BootStrap-Nuget -NugetPath $NuGetPath
 
 Export-ModuleMember -Function $Public.Basename

--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -7,29 +7,32 @@
 @{
 
     FileDownload = @{
-      Script= 'FileDownload.ps1'
-      Description = 'Download a file'
+        Script= 'FileDownload.ps1'
+        Description = 'Download a file'
+    }
+
+    Git = @{
+        Script = 'Git.ps1'
+        Description = 'Clone a git repository'
     }
 
     Noop = @{
-      Script = 'noop.ps1'
-      Description = 'Display parameters that a depends script would receive. Use for testing and validation.'
+        Script = 'noop.ps1'
+        Description = 'Display parameters that a depends script would receive. Use for testing and validation.'
     }
 
     PSGalleryModule = @{
-      Script= 'PSGalleryModule.ps1'
-      Description = 'Install a PowerShell module from the PowerShell Gallery.'
+        Script= 'PSGalleryModule.ps1'
+        Description = 'Install a PowerShell module from the PowerShell Gallery.'
     }
 
     PSGalleryNuget = @{
-      Script = 'PSGalleryNuget.ps1'
-      Description = 'Install a PowerShell module from the PowerShell Gallery without the PowerShellGet dependency'
+        Script = 'PSGalleryNuget.ps1'
+        Description = 'Install a PowerShell module from the PowerShell Gallery without the PowerShellGet dependency'
     }
 
     Task = @{
-      Script = 'Task.ps1'
-      Description = 'Support dependencies by handling simple tasks.'
+        Script = 'Task.ps1'
+        Description = 'Support dependencies by handling simple tasks.'
     }
-
-
 }

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -8,16 +8,16 @@
         Note: We require git.exe in your path
 
         Relevant Dependency metadata:
-            DependencyName (Key): Git URL.
+            DependencyName (Key): Git URL
                 You can override this with the 'Name'.
                 If you specify only an Account/Repository, we assume GitHub is the source
             Name: Optional override for the Git URL, same rules as DependencyName (key)
             Version: Used with git checkout.  Specify a branch name, commit hash, or tags/<tag name>, for example.  Defaults to master
-            Target: Path to clone this repository.  Defaults to current path.
+            Target: Path to clone this repository.  Defaults to nothing (current path/repo name)
             AddToPath: Add the Target to ENV:PATH and ENV:PSModulePath
 
     .PARAMETER Force
-        If specified and Target is specified, create folders to Target if needed
+        If specified and target does not exist, create directory tree up to the target folder
 
     .EXAMPLE
         @{
@@ -44,8 +44,8 @@
         # Simple syntax
           # First example shows cloning PSDeploy from ramblingcookiemonster's GitHub account
           # Second example shows clonging PSDeploy from ramblingcookiemonster's GitHub account and checking out a specific commit
-          # Both are cloned to the current path
-          # This syntax assumes GitHub as a source, the right hand side is the version (branch, commit, tags/<tag name>, etc.
+          # Both are cloned to the current path (e.g. .\<repo name>)
+          # This syntax assumes GitHub as a source. The right hand side is the version (branch, commit, tags/<tag name>, etc.
 #>
 [cmdletbinding()]
 param(
@@ -63,6 +63,28 @@ param(
         $Name = $DependencyName
     }
 
+    #Name is in account/repo format, default to GitHub as source
+    #This likely needs work, and will need to change if GitHub changes valid characters for usernames
+    if($Name -match "[a-zA-Z0-9]+/[a-zA-Z0-9_-]+")
+    {
+        $Name = "https://github.com/$Name.git"
+    }
+    $GitName = $Name.split('/')[-1] -replace "\.git[/]?$", ''
+
+    $Target = $Dependency.Target
+    if($Target)
+    {
+        $RepoPath = $Target
+        if(-not (Test-Path $Target))
+        {
+            mkdir $Target -Force
+        }
+    }
+    else
+    {
+        $RepoPath = Join-Path $PWD.Path $GitName
+    }
+
     $Version = $Dependency.Version
     if(-not $Version)
     {
@@ -74,80 +96,29 @@ if(-not (Get-Command git.exe -ErrorAction SilentlyContinue))
     Write-Error "Git dependency type requires git.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's GitPath.  Skipping [$DependencyName]"
 }
 
-Write-Verbose -Message "Getting dependency [$DependencyName] from Nuget source [$Source]"
-
+Write-Verbose -Message "Cloning dependency [$Name] with git"
 $CloneParams = @('clone', $Name)
 if($Target)
 {
     $CloneParams += $Target
 }
 
-if(Test-Path $ModulePath)
+#TODO: Add logic to test for existing repo
+git @CloneParams
+Push-Location
+Set-Location $RepoPath
+
+#TODO: Should we do a fetch, once existing repo is found?
+Write-Verbose -Message "Checking out [$Version] of [$Name]"
+$CheckoutParams = @('checkout', $Version)
+git @CheckoutParams
+Pop-Location
+
+if($Dependency.AddToPath)
 {
-    $Manifest = Join-Path $ModulePath "$Name.psd1"
-    if(-not (Test-Path $Manifest))
-    {
-        # For now, skip if we don't find a psd1
-        Write-Error "Could not find manifest [$Manifest] for dependency [$DependencyName]"
-        return
-    }
-
-    Write-Verbose "Found existing module [$DependencyName]"
-
-    # Thanks to Brandon Padgett!
-    $ManifestData = Import-LocalizedData -BaseDirectory $ModulePath -FileName "$Name.psd1"
-    $ExistingVersion = $ManifestData.ModuleVersion
-    $GalleryVersion = ( Find-NugetPackage -Name $Name -PackageSourceUrl $Source -IsLatest ).Version
+    Write-Verbose "Setting PSModulePath to`n$($env:PSModulePath, $RepoPath -join ';' | Out-String)"
+    $env:PSModulePath = $env:PSModulePath, $RepoPath -join ';'
     
-    # Version string, and equal to current
-    if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)
-    {
-        Write-Verbose "You have the requested version [$Version] of [$Name]"
-        return $null
-    }
-    
-    # latest, and we have latest
-    if( $Version -and
-        ($Version -eq 'latest' -or $Version -like '') -and
-        $GalleryVersion -le $ExistingVersion
-    )
-    {
-        Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
-        return $null
-    }
-
-    Write-Verbose "Removing existing [$ModulePath]`nContinuing to install [$Name]: Requested version [$version], existing version [$ExistingVersion], PSGallery version [$GalleryVersion]"
-    Remove-Item $ModulePath -Force -Recurse 
-}
-
-if(($TargetExists = Test-Path $Target -PathType Container) -or $Force)
-{
-    Write-Verbose "Saving [$Name] with path [$Target]"
-    $NugetParams = '-Source', $Source, '-ExcludeVersion', '-NonInteractive', '-OutputDirectory', $Target
-    if($Force)
-    {
-        Write-Verbose "Force creating directory path to [$Target]"
-        $Null = New-Item -ItemType Directory -Path $Target -Force -ErrorAction SilentlyContinue
-    }
-    if($Version -and $Version -notlike 'latest')
-    {
-        $NugetParams += '-version', $Version
-    }
-    nuget.exe install $Name @NugetParams
-
-    if($Dependency.AddToPath)
-    {
-        Write-Verbose "Setting PSModulePath to`n$($env:PSModulePath, $Scope -join ';' | Out-String)"
-        $env:PSModulePath = $env:PSModulePath, $Target -join ';'
-    }
-}
-else
-{
-    Write-Error "Target [$Target] exists must be true, and is [$TargetExists]. Alternatively, specify -Force to create the Target"
-}
-
-if($Import)
-{
-    Write-Verbose "Importing [$ModulePath]"
-    Import-Module $ModulePath -Scope Global -Force 
+    Write-Verbose "Setting PATH to`n$($env:PATH, $RepoPath -join ';' | Out-String)"
+    $env:PATH = $env:PATH, $RepoPath -join ';'
 }

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -129,13 +129,34 @@ function Get-Dependency {
                 $DependencyHash = $Dependencies.$Dependency
 
                 #Parse simple key=name, value=version format
-                if($DependencyHash -is [string])
+                if($DependencyHash -is [string] -and $Dependency -notmatch '/')
                 {
                     [pscustomobject]@{
                         PSTypeName = 'PSDepend.Dependency'
                         DependencyFile = $DependencyFile
                         DependencyName = $Dependency
                         DependencyType = 'PSGalleryModule'
+                        Name = $Dependency
+                        Version = $DependencyHash
+                        Parameters = $null
+                        Source = $null
+                        Target = $null
+                        AddToPath = $null
+                        Tags = $null
+                        DependsOn = $null
+                        PreScripts = $null
+                        PostScripts = $null
+                        PSDependOptions = $PSDependOptions
+                        Raw = $null
+                    }
+                }
+                elseif($DependencyHash -is [string] -and $Dependency -match '/')
+                {
+                    [pscustomobject]@{
+                        PSTypeName = 'PSDepend.Dependency'
+                        DependencyFile = $DependencyFile
+                        DependencyName = $Dependency
+                        DependencyType = 'Git'
                         Name = $Dependency
                         Version = $DependencyHash
                         Parameters = $null

--- a/PSDepend/en-US/about_PSDepend.help.txt
+++ b/PSDepend/en-US/about_PSDepend.help.txt
@@ -27,7 +27,7 @@ DETAILED DESCRIPTION
                                 For example, the PSGalleryModule script uses PowerShellGet to find
                                 and install any dependencies specified in a depend.psd1 or requirements.psd1 file.
 
-    Dependencies
+    Prerequisites
     ============
     
     Each dependency type may have certain prerequisites:
@@ -36,9 +36,10 @@ DETAILED DESCRIPTION
       * PSGalleryNuget:  This requires nuget.exe in your path*.  We handle this for you:
                          When you import PSDepend, we... 
                             Look for nuget.exe in your path. 
-                            If we don't find it... Look in the path specified in PSDepend\PSDepend.NugetPath. Default is PSDepend\nuget.exe
+                            If we don't find it... Look in the path specified in PSDepend\PSDepend.Config's NugetPath. Default is PSDepend\nuget.exe
                                 If we don't find it there, we download to that path
-                                If we do find it there, we add the parent container to $ENV:Path 
+                                If we do find it there, we add the parent container to $ENV:Path
+      * Git: Requires git.exe in your path, or in the file path specified in PSDepend\PSDepend.Config's GitPath
                             
     Example use (*.PSDepend.ps1)
     ============================

--- a/PSDepend/en-US/about_PSDepend_Definitions.help.txt
+++ b/PSDepend/en-US/about_PSDepend_Definitions.help.txt
@@ -24,7 +24,7 @@ DETAILED DESCRIPTION
             DependencyFile: File that we read a dependency from
             DependencyName: Unique name within a dependency file - this is the key, the rest of the data is stored in this key's value.
             DependencyType: The dependency type.  Defaults to PSGalleryModule
-            Name:           Name of the thing to deploy.  Optional, use this if DependencyName has a collision
+            Name:           Name of the thing to install.  Optional, use this if DependencyName has a collision
             Version:        Version to install and check for.  The dependency script author is responsible for testing whether this version already exists and installing it if not.
             Parameters:     Optional parameters if the dependency type's script takes parameters.  For example, the PSGalleryModule has an optional 'Repository' parameter.
             Source:         Optional source.  For example, a FileDownload source is a URL
@@ -87,28 +87,28 @@ DETAILED DESCRIPTION
                 }
             }
 
-    Dependency type map: PSDeployMap.psd1
+    Dependency type map: PSDependMap.psd1
     ================================
 
-    This is a file that tells PSDeploy what script to use for each DeploymentType. By default, it sits in your PSDeploy module folder.
+    This is a file that tells PSDepend what script to use for each DependencyType. By default, it sits in your PSDepend module folder.
 
     There are two scenarios you would generally work with this:
 
-      - You want to extend PSDeploy to add more DeploymentTypes
-      - You want to move the PSDeploy.yml to a central location that multiple systems could point to
+      - You want to extend PSDepend to add more DependencyTypes
+      - You want to move the PSDependMap.psd1 to a central location that multiple systems could point to
 
-    There are three attributes to each DeploymentType in this file:
+    There are three attributes to each DependencyType in this file:
 
-        DeploymentType Name:  The name of this DeploymentType
-        Script:               The name of the script to process these DeploymentTypes
-                              This looks in the PSDeploy module path, under PSDeployScripts
+        DependencyType Name:  The name of this DependencyType
+        Script:               The name of the script to process these DependencyTypes
+                              This looks in the PSDepend module path, under PSDependScripts
                               You can theoretically specify an absolute path
-        Description:          Description for this DeploymentType. Provided to a user when they run Get-PSDeploymentType.
+        Description:          Description for this DependencyType. Provided to a user when they run Get-PSDependType.
 
-    The PSDeploy.yml file will have one or more DeploymentType blocks like this:
+    The PSDependMap.psd1 file will have one or more DependencyType blocks like this:
 
-        Filesystem:
-          Script: Filesystem.ps1
-          Description: Uses the current session and Robocopy or Copy-Item for folder and file deployments, respectively.
+        PSGalleryModule:
+          Script: PSGalleryModule.ps1
+          Description: Install a PowerShell module from the PowerShell Gallery.
 
-    See about_PSDeploy for more information
+    See about_PSDepend for more information

--- a/PSDepend/en-US/about_PSDepend_Definitions.help.txt
+++ b/PSDepend/en-US/about_PSDepend_Definitions.help.txt
@@ -7,7 +7,8 @@ SHORT DESCRIPTION
 LONG DESCRIPTION
     PSDepend has several configuration definitions to work with:
 
-        Dependency configurations:      *.Depend.psd1 or requirements.psd1 script files
+        Dependency configurations:       *.Depend.psd1 or requirements.psd1 script files
+        PSDepend configuration:          PSDepend.Config file with a few configurations for PSDepend
         Dependency type configurations:  Map Dependency types to scripts that run them
 
     Please see about_PSDepend or other general PSDepend help for clarification on terminology
@@ -87,8 +88,16 @@ DETAILED DESCRIPTION
                 }
             }
 
+    PSDepend configuration: PSDepend.Config
+    =======================================
+
+    This file includes a few configurations for PSDepend:
+        
+        NugetPath: Path to a nuget.exe, if it's not in your path.  If it's not found in either spot, we download to this
+        GitPath: Path to a git.exe, if it's not in your path.  We do not resolve this dependency for you (yet).
+
     Dependency type map: PSDependMap.psd1
-    ================================
+    =====================================
 
     This is a file that tells PSDepend what script to use for each DependencyType. By default, it sits in your PSDepend module folder.
 

--- a/README.md
+++ b/README.md
@@ -30,21 +30,24 @@ Here's the simplest syntax.  If this meets your needs, you can stop here:
     Pester       = 'latest'
     BuildHelpers = '0.0.20'  # I don't trust this Warren guy...
     PSDeploy     = '0.1.21'  # Maybe pin the version in case he breaks this...
+    
+    RamblingCookieMonster/PowerShell = 'master'
 }
 ```
 
 And what PSDepend sees:
 
 ```
-DependencyName DependencyType  Version Tags
--------------- --------------  ------- ----
-psake          PSGalleryModule latest
-BuildHelpers   PSGalleryModule 0.0.20
-Pester         PSGalleryModule
-PSDeploy       PSGalleryModule 0.1.21
+DependencyName                   DependencyType  Version Tags
+--------------                   --------------  ------- ----
+psake                            PSGalleryModule latest      
+BuildHelpers                     PSGalleryModule 0.0.20      
+Pester                           PSGalleryModule latest      
+RamblingCookieMonster/PowerShell Git             master      
+PSDeploy                         PSGalleryModule 0.1.21   
 ```
 
-There's a bit more behind the scenes - we assume you want PSGalleryModule's unless you specify otherwise, and we hide a few dependency properties.
+There's a bit more behind the scenes - we assume you want PSGalleryModules or GitHub repos unless you specify otherwise, and we hide a few dependency properties.
 
 ### Flexible syntax
 
@@ -76,7 +79,7 @@ What else can we put in a dependency?  Here's an example using a more flexible s
         DependencyType = 'FileDownload'
         Source = 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe'
         Target = 'C:\nuget.exe'
-    }
+    }  
 }
 ```
 
@@ -160,4 +163,4 @@ Get-Help Get-Dependency -Full
 
 ## Notes
 
-Major props to Michael Willis, who is writing [PSRequire](https://github.com/Xainey/PSRequire), a similar but more feature-full solution.
+Major props to Michael Willis for the idea - check out his [PSRequire](https://github.com/Xainey/PSRequire), a similar but more feature-full solution.


### PR DESCRIPTION
Add Git dependency type and supporting code.

PSDepend simple syntax ( key = "string" vs. key = @{} ) will now default to GitHub repos if we see a `\`, PSGalleryModules otherwise.  This same code also allows using fully qualified git clone URLs as the name, without specifying a DependencyType.

At the moment, we use `Version` as the value for a git checkout, allowing you to checkout a specific branch, commit, or even a tag. (tags:tagname).