### PR TITLE
Add PSDependAction, Test/Import-Dependency

### DIFF
--- a/PSDepend/PSDependScripts/FileDownload.ps1
+++ b/PSDepend/PSDependScripts/FileDownload.ps1
@@ -122,14 +122,10 @@ param(
 
 if($PSDependAction -contains 'Install')
 {
-    # We have the info, check for file, download it!
-    $webclient = New-Object System.Net.WebClient
-
     # Future considerations:
         # Should we check for existing? And if we find it, still download file, and compare sha256 hash, replace if it does not match?
         # We should consider credentials at some point, but PSD1 does not lend itself to securely storing passwords
-
-    $webclient.DownloadFile($URL, $Path)
+    Get-WebFile -URL $URL -Path $Path
 }
 
 if($Dependency.AddToPath)

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -27,10 +27,10 @@
 
     .EXAMPLE
         @{
-            'buildhelpers' @{
+            'buildhelpers' = @{
                 Name = 'https://github.com/RamblingCookieMonster/BuildHelpers.git'
                 Version = 'd32a9495c39046c851ceccfb7b1a85b17d5be051'
-                Target = C:\git
+                Target = 'C:\git'
             }
         }
 
@@ -138,14 +138,14 @@ if($Target)
 }
 
 #TODO: Add logic to test for existing repo
-git @CloneParams
+Invoke-ExternalCommand git $CloneParams
 Push-Location
 Set-Location $RepoPath
 
 #TODO: Should we do a fetch, once existing repo is found?
 Write-Verbose -Message "Checking out [$Version] of [$Name]"
 $CheckoutParams = @('checkout', $Version)
-git @CheckoutParams
+Invoke-ExternalCommand git $CheckoutParams
 Pop-Location
 
 if($Dependency.AddToPath)

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -136,8 +136,8 @@ Set-Location $RepoPath
 
 if($GottaTest)
 {
-    $Branch = git rev-parse --abbrev-ref HEAD
-    $Commit = git rev-parse HEAD
+    $Branch = Invoke-ExternalCommand git (echo rev-parse --abbrev-ref HEAD)
+    $Commit = Invoke-ExternalCommand git (echo rev-parse HEAD)
     if($Version -eq $Branch -or $Version -eq $Commit)
     {
         Write-Verbose "[$RepoPath] exists and is already at version [$Version]"

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -74,7 +74,7 @@ if(-not $Name)
 
 #Name is in account/repo format, default to GitHub as source
 #This likely needs work, and will need to change if GitHub changes valid characters for usernames
-if($Name -match "[a-zA-Z0-9]+/[a-zA-Z0-9_-]+")
+if($Name -match "^[a-zA-Z0-9]+/[a-zA-Z0-9_-]+$")
 {
     $Name = "https://github.com/$Name.git"
 }
@@ -94,7 +94,8 @@ if($Target)
         }
         if( $PSDependAction -contains 'Install')
         {
-            mkdir $Target -Force
+            Write-Verbose "Creating folder [$Target] for git dependency [$Name]"
+            $null = mkdir $Target -Force
         }
     }
 }

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -128,6 +128,9 @@ if($Existing)
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)
     {
         Write-Verbose "You have the requested version [$Version] of [$Name]"
+        # Conditional import
+        Import-PSDependModule -Name $ModuleName -Action $PSDependAction
+
         if($PSDependAction -contains 'Test')
         {
             return $True
@@ -142,6 +145,10 @@ if($Existing)
     )
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
+        
+        # Conditional import
+        Import-PSDependModule -Name $ModuleName -Action $PSDependAction
+
         if($PSDependAction -contains 'Test')
         {
             return $True
@@ -183,8 +190,5 @@ if($PSDependAction -contains 'Install')
     }
 }
 
-if($Import -or $PSDependAction -contains 'Import')
-{
-    Write-Verbose "Importing [$ModuleName]"
-    Import-Module $ModuleName -Scope Global -Force 
-}
+# Conditional import
+Import-PSDependModule -Name $ModuleName -Action $PSDependAction

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -21,6 +21,15 @@
 
     .PARAMETER Import
         If specified, import the module in the global scope
+
+        Deprecated.  Moving to PSDependAction
+
+    .PARAMETER PSDependAction
+        Test, Install, or Import the module.  Defaults to Install
+
+        Test: Return true or false on whether the dependency is in place
+        Install: Install the dependency
+        Import: Import the dependency
 #>
 [cmdletbinding()]
 param(
@@ -31,7 +40,10 @@ param(
 
     [switch]$Force,
 
-    [switch]$Import
+    [switch]$Import,
+
+    [ValidateSet('Test', 'Install', 'Import')]
+    [string[]]$PSDependAction = @('Install')
 )
 
 # Extract data from Dependency
@@ -116,6 +128,10 @@ if($Existing)
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)
     {
         Write-Verbose "You have the requested version [$Version] of [$Name]"
+        if($PSDependAction -contains 'Test')
+        {
+            return $True
+        }
         return $null
     }
     
@@ -126,36 +142,48 @@ if($Existing)
     )
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
+        if($PSDependAction -contains 'Test')
+        {
+            return $True
+        }
         return $null
     }
 
     Write-Verbose "Continuing to install [$Name]: Requested version [$version], existing version [$ExistingVersion], PSGallery version [$GalleryVersion]"
 }
 
-$ImportParam = @{}
-if('AllUsers', 'CurrentUser' -contains $Scope)
-{   
-    Write-Verbose "Installing [$Name] with scope [$Scope]"
-    Install-Module @params -Scope $Scope
-}
-elseif((Test-Path $Scope -PathType Container) -or $Force)
+#No dependency found, return false if we're testing alone...
+if( $PSDependAction -contains 'Test' -and $PSDependAction.count -eq 1)
 {
-    Write-Verbose "Saving [$Name] with path [$Scope]"
-    if($Force)
-    {
-        Write-Verbose "Force creating directory path to [$Scope]"
-        $Null = New-Item -ItemType Directory -Path $Scope -Force -ErrorAction SilentlyContinue
-    }
-    Save-Module @params -Path $Scope
+    return $False
+}
 
-    if($Dependency.AddToPath)
+if($PSDependAction -contains 'Install')
+{
+    if('AllUsers', 'CurrentUser' -contains $Scope)
+    {   
+        Write-Verbose "Installing [$Name] with scope [$Scope]"
+        Install-Module @params -Scope $Scope
+    }
+    elseif((Test-Path $Scope -PathType Container) -or $Force)
     {
-        Write-Verbose "Setting PSModulePath to`n$($Scope, $env:PSModulePath -join ';' | Out-String)"
-        $env:PSModulePath = $Scope, $env:PSModulePath -join ';'
+        Write-Verbose "Saving [$Name] with path [$Scope]"
+        if($Force)
+        {
+            Write-Verbose "Force creating directory path to [$Scope]"
+            $Null = New-Item -ItemType Directory -Path $Scope -Force -ErrorAction SilentlyContinue
+        }
+        Save-Module @params -Path $Scope
+
+        if($Dependency.AddToPath)
+        {
+            Write-Verbose "Setting PSModulePath to`n$($Scope, $env:PSModulePath -join ';' | Out-String)"
+            $env:PSModulePath = $Scope, $env:PSModulePath -join ';'
+        }
     }
 }
 
-if($Import)
+if($Import -or $PSDependAction -contains 'Import')
 {
     Write-Verbose "Importing [$ModuleName]"
     Import-Module $ModuleName -Scope Global -Force 

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -125,6 +125,8 @@ if(Test-Path $ModulePath)
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)
     {
         Write-Verbose "You have the requested version [$Version] of [$Name]"
+        # Conditional import
+        Import-PSDependModule -Name $ModulePath -Action $PSDependAction
         if($PSDependAction -contains 'Test')
         {
             return $True
@@ -139,6 +141,8 @@ if(Test-Path $ModulePath)
     )
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
+        # Conditional import
+        Import-PSDependModule -Name $ModulePath -Action $PSDependAction
         if($PSDependAction -contains 'Test')
         {
             return $True
@@ -185,8 +189,5 @@ if($PSDependAction -contains 'Install')
     }
 }
 
-if($Import -or $PSDependAction -contains 'Import')
-{
-    Write-Verbose "Importing [$ModulePath]"
-    Import-Module $ModulePath -Scope Global -Force 
-}
+# Conditional import
+Import-PSDependModule -Name $ModulePath -Action $PSDependAction

--- a/PSDepend/Private/Get-Parameter.ps1
+++ b/PSDepend/Private/Get-Parameter.ps1
@@ -1,0 +1,224 @@
+﻿# Borrowed from http://poshcode.org/5929 with a minor tweak for validateset - thanks all!
+Function Get-Parameter {
+   #.Synopsis 
+   #  Enumerates the parameters of one or more commands
+   #.Description
+   #  Lists all the parameters of a command, by ParameterSet, including their aliases, type, etc.
+   #
+   #  By default, formats the output to tables grouped by command and parameter set
+   #.Example
+   #  Get-Command Select-Xml | Get-Parameter
+   #.Example
+   #  Get-Parameter Select-Xml
+   [CmdletBinding(DefaultParameterSetName="ParameterName")]
+   param(
+      # The name of the command to get parameters for
+      [Parameter(Position = 1, Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+      [Alias("Name")]
+      [string[]]$CommandName,
+
+      # The parameter name to filter by (allows Wilcards)
+      [Parameter(Position = 2, ValueFromPipelineByPropertyName=$true, ParameterSetName="FilterNames")]
+      [string[]]$ParameterName = "*",
+
+      # The ParameterSet name to filter by (allows wildcards)
+      [Parameter(ValueFromPipelineByPropertyName=$true, ParameterSetName="FilterSets")]
+      [string[]]$SetName = "*",
+
+      # The name of the module which contains the command (this is for scoping)
+      [Parameter(ValueFromPipelineByPropertyName = $true)]
+      $ModuleName,
+
+      # Skip testing for Provider parameters (will be much faster)
+      [Switch]$SkipProviderParameters,
+
+      # Forces including the CommonParameters in the output
+      [switch]$Force
+   )
+
+   begin {
+      $PropertySet = @( "Name",
+         @{n="Position";e={if($_.Position -lt 0){"Named"}else{$_.Position}}},
+         "Aliases", 
+         @{n="Short";e={$_.Name}},
+         @{n="Type";e={$_.ParameterType.Name}}, 
+         @{n="ParameterSet";e={$paramset}},
+         @{n="Command";e={$command}},
+         @{n="Mandatory";e={$_.IsMandatory}},
+         @{n="Provider";e={$_.DynamicProvider}},
+         @{n="ValueFromPipeline";e={$_.ValueFromPipeline}},
+         @{n="ValueFromPipelineByPropertyName";e={$_.ValueFromPipelineByPropertyName}},
+         "ValidateSetValues" # This is a bit specific and not always applicable, but need it for this project....
+      )
+      function Join-Object {
+         Param(
+           [Parameter(Position=0)]
+           $First,
+
+           [Parameter(ValueFromPipeline=$true,Position=1)]
+           $Second
+         )
+         begin {
+           [string[]] $p1 = $First | Get-Member -MemberType Properties | Select-Object -ExpandProperty Name
+         }
+         process {
+           $Output = $First | Select-Object $p1
+           foreach ($p in $Second | Get-Member -MemberType Properties | Where-Object {$p1 -notcontains $_.Name} | Select-Object -ExpandProperty Name) {
+              Add-Member -InputObject $Output -MemberType NoteProperty -Name $p -Value $Second."$p"
+           }
+           $Output
+         }
+      }
+
+      function Add-Parameters {
+         [CmdletBinding()]
+         param(
+            [Parameter(Position=0)]
+            [Hashtable]$Parameters,
+
+            [Parameter(Position=1)]
+            [System.Management.Automation.ParameterMetadata[]]$MoreParameters
+         )
+
+         foreach ($p in $MoreParameters | Where-Object { !$Parameters.ContainsKey($_.Name) } ) {
+            Write-Debug ("INITIALLY: " + $p.Name)
+            $Parameters.($p.Name) = $p | Select *
+         }
+
+         [Array]$Dynamic = $MoreParameters | Where-Object { $_.IsDynamic }
+         if ($dynamic) {
+            foreach ($d in $dynamic) {
+               if (Get-Member -InputObject $Parameters.($d.Name) -Name DynamicProvider) {
+                  Write-Debug ("ADD:" + $d.Name + " " + $provider.Name)
+                  $Parameters.($d.Name).DynamicProvider += $provider.Name
+               } else {
+                  Write-Debug ("CREATE:" + $d.Name + " " + $provider.Name)
+                  $Parameters.($d.Name) = $Parameters.($d.Name) | Select *, @{ n="DynamicProvider";e={ @($provider.Name) } }
+               }
+            } 
+         }
+      }
+   }
+
+   process {
+      foreach ($cmd in $CommandName) {
+         if ($ModuleName) {$cmd = "$ModuleName\$cmd"}
+         Write-Verbose "Searching for $cmd"
+         $commands = @(Get-Command $cmd)
+
+         foreach ($command in $commands) {
+            Write-Verbose "Searching for $command"
+            # resolve aliases (an alias can point to another alias)
+            while ($command.CommandType -eq "Alias") {
+              $command = @(Get-Command ($command.definition))[0]
+            }
+            if (-not $command) {continue}
+
+            Write-Verbose "Get-Parameters for $($Command.Source)\$($Command.Name)"
+
+            $Parameters = @{}
+
+            ## We need to detect provider parameters ...
+            $NoProviderParameters = !$SkipProviderParameters
+            ## Shortcut: assume only the core commands get Provider dynamic parameters
+            if(!$SkipProviderParameters -and $Command.Source -eq "Microsoft.PowerShell.Management") {
+               ## The best I can do is to validate that the command has a parameter which could accept a string path
+               foreach($param in $Command.Parameters.Values) {
+                  if(([String[]],[String] -contains $param.ParameterType) -and ($param.ParameterSets.Values | Where { $_.Position -ge 0 })) {
+                     $NoProviderParameters = $false
+                     break
+                  }
+               }
+            }
+
+            if($NoProviderParameters) {
+               if($Command.Parameters) {
+                  Add-Parameters $Parameters $Command.Parameters.Values
+               }
+            } else {
+               foreach ($provider in Get-PSProvider) {
+                  if($provider.Drives.Length -gt 0) {
+                     $drive = Get-Location -PSProvider $Provider.Name
+                  } else {
+                     $drive = "{0}\{1}::\" -f $provider.ModuleName, $provider.Name
+                  }
+                  Write-Verbose ("Get-Command $command -Args $drive | Select -Expand Parameters")
+
+                  try {
+                     $MoreParameters = (Get-Command $command -Args $drive).Parameters.Values
+                  } catch {}
+       
+                  if($MoreParameters.Length -gt 0) {
+                     Add-Parameters $Parameters $MoreParameters
+                  }
+               }
+               # If for some reason none of the drive paths worked, just use the default parameters
+               if($Parameters.Length -eq 0) {
+                  if($Command.Parameters) {
+                     Add-Parameters $Parameters $Command.Parameters.Values
+                  }
+               }
+            }
+
+            ## Calculate the shortest distinct parameter name -- do this BEFORE removing the common parameters or else.
+            $Aliases = $Parameters.Values | Select-Object -ExpandProperty Aliases  ## Get defined aliases
+            $ParameterNames = $Parameters.Keys + $Aliases
+            foreach ($p in $($Parameters.Keys)) {
+               $short = "^"
+               $aliases = @($p) + @($Parameters.$p.Aliases) | sort { $_.Length }
+               $shortest = "^" + @($aliases)[0]
+
+               foreach($name in $aliases) {
+                  $short = "^"
+                  foreach ($char in [char[]]$name) {         
+                     $short += $char
+                     $mCount = ($ParameterNames -match $short).Count
+                     if ($mCount -eq 1 ) {
+                        if($short.Length -lt $shortest.Length) {
+                           $shortest = $short
+                        }
+                        break
+                     }
+                  }
+               }
+               if($shortest.Length -lt @($aliases)[0].Length +1){
+                  # Overwrite the Aliases with this new value
+                  $Parameters.$p = $Parameters.$p | Add-Member NoteProperty Aliases ($Parameters.$p.Aliases + @("$($shortest.SubString(1))*")) -Force -Passthru
+               }
+
+               # ValidateSet...
+               $Parameters.$p = $Parameters.$p | Add-Member NoteProperty ValidateSetValues ($Parameters.$p.Attributes | Where{$_.TypeId.name -like 'ValidateSetAttribute'}).ValidValues -Force -Passthru
+
+            }
+
+            # Write-Verbose "Parameters: $($Parameters.Count)`n $($Parameters | ft | out-string)"
+            $CommonParameters = [string[]][System.Management.Automation.Cmdlet]::CommonParameters
+
+            foreach ($paramset in @($command.ParameterSets | Select-Object -ExpandProperty "Name")) {
+               $paramset = $paramset | Add-Member -Name IsDefault -MemberType NoteProperty -Value ($paramset -eq $command.DefaultParameterSet) -PassThru
+               foreach ($parameter in $Parameters.Keys | Sort-Object) {
+                  # Write-Verbose "Parameter: $Parameter"
+                  if (!$Force -and ($CommonParameters -contains $Parameter)) {continue}
+                  if ($Parameters.$Parameter.ParameterSets.ContainsKey($paramset) -or $Parameters.$Parameter.ParameterSets.ContainsKey("__AllParameterSets")) {
+                     if ($Parameters.$Parameter.ParameterSets.ContainsKey($paramset)) {
+                        $output = Join-Object $Parameters.$Parameter $Parameters.$Parameter.ParameterSets.$paramSet 
+                     } else {
+                        $output = Join-Object $Parameters.$Parameter $Parameters.$Parameter.ParameterSets.__AllParameterSets
+                     }
+
+                     Write-Output $Output | Select-Object $PropertySet | ForEach-Object {
+                           $null = $_.PSTypeNames.Insert(0,"System.Management.Automation.ParameterMetadata")
+                           $null = $_.PSTypeNames.Insert(0,"System.Management.Automation.ParameterMetadataEx")
+                           # Write-Verbose "$(($_.PSTypeNames.GetEnumerator()) -join ", ")"
+                           $_
+                        } |
+                        Add-Member ScriptMethod ToString { $this.Name } -Force -Passthru |
+                        Where-Object {$(foreach($pn in $ParameterName) {$_ -like $Pn}) -contains $true} |
+                        Where-Object {$(foreach($sn in $SetName) {$_.ParameterSet -like $sn}) -contains $true}
+                  }
+               }
+            }
+         }
+      }
+   }
+}

--- a/PSDepend/Private/Get-WebFile.ps1
+++ b/PSDepend/Private/Get-WebFile.ps1
@@ -1,0 +1,8 @@
+﻿# Wrapped for pester mocking...
+Function Get-WebFile {
+    param($URL, $Path)
+    # We have the info, check for file, download it!
+    $webclient = New-Object System.Net.WebClient
+    $webclient.DownloadFile($URL, $Path)
+    $webclient.Dispose()
+}

--- a/PSDepend/Private/Import-PSDependModule.ps1
+++ b/PSDepend/Private/Import-PSDependModule.ps1
@@ -1,0 +1,12 @@
+﻿function Import-PSDependModule {
+    [cmdletbinding()]
+    param (
+        $Name = $ModulePath,
+        $Action = $PSDependAction
+    )
+    if($PSDependAction -contains 'Import')
+    {
+        Write-Verbose "Importing [$Name]"
+        Import-Module $Name -Scope Global -Force 
+    }
+}

--- a/PSDepend/Private/Invoke-ExternalCommand.ps1
+++ b/PSDepend/Private/Invoke-ExternalCommand.ps1
@@ -4,6 +4,7 @@ function Invoke-ExternalCommand {
     [cmdletbinding()]
     param($Command, [string[]]$Arguments)
 
+    Write-Verbose "Running $Command with arguments $($Arguments -join "; ")"
     $result = $null
     $result = & $command @arguments  
     Write-Verbose "$($result | Out-String)"

--- a/PSDepend/Private/Invoke-ExternalCommand.ps1
+++ b/PSDepend/Private/Invoke-ExternalCommand.ps1
@@ -1,0 +1,10 @@
+﻿# Pester wasn't mocking git... 
+# Borrowed idea from https://github.com/pester/Pester/issues/415
+function Invoke-ExternalCommand {
+    [cmdletbinding()]
+    param($Command, [string[]]$Arguments)
+
+    $result = $null
+    $result = & $command @arguments  
+    Write-Verbose "$($result | Out-String)"
+}

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -182,7 +182,7 @@ function Get-Dependency {
                         # Look for git format:
                         if(
                             ($Dependency -match '/' -and -not $Dependency.Name) -or
-                            $Dependency.Name -match '/'
+                            $DependencyHash.Name -match '/'
                         )
                         {
                             $DependencyHash.add('DependencyType', 'Git')

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -107,7 +107,7 @@ function Get-Dependency {
         {
             $DependencyFiles = @( $DependencyPath )
         }
-        $DependencyFiles = $DependencyFiles | Select -Unique
+        $DependencyFiles = $DependencyFiles | Select-Object -Unique
 
         $DependencyMap = foreach($DependencyFile in $DependencyFiles)
         {

--- a/PSDepend/Public/Get-PSDependType.ps1
+++ b/PSDepend/Public/Get-PSDependType.ps1
@@ -73,7 +73,7 @@ Function Get-PSDependType {
     $File = Split-Path $Path -Leaf
     $DependencyDefinitions = Import-LocalizedData -BaseDirectory $Base -FileName $File
 
-    foreach($Type in ($DependencyDefinitions.Keys | Where {$_ -like $DependencyType}))
+    foreach($Type in ($DependencyDefinitions.Keys | Where-Object {$_ -like $DependencyType}))
     {
         #Determine the path to this script. Skip task dependencies...
         $Script =  $DependencyDefinitions.$Type.Script

--- a/PSDepend/Public/Import-Dependency.ps1
+++ b/PSDepend/Public/Import-Dependency.ps1
@@ -47,9 +47,7 @@ Function Import-Dependency {
     .LINK
         https://github.com/RamblingCookieMonster/PSDepend
     #>
-    [cmdletbinding( DefaultParameterSetName = 'Map',
-                    SupportsShouldProcess = $True,
-                    ConfirmImpact='High' )]
+    [cmdletbinding()]
     Param(
         [parameter( ValueFromPipeline = $True,
                     ParameterSetName='Map',
@@ -73,10 +71,9 @@ Function Import-Dependency {
 
         #Get definitions, and dependencies in this particular psd1
         $DependencyDefs = Get-PSDependScript
-        $TheseDependencyTypes = @( $Dependency.DependencyType | Sort -Unique )
+        $TheseDependencyTypes = @( $Dependency.DependencyType | Sort-Object -Unique )
 
         #Build up hash, we call each dependencytype script for applicable dependencies
-        $ToTest = @{}
         foreach($DependencyType in $TheseDependencyTypes)
         {
             $DependencyScript = $DependencyDefs.$DependencyType

--- a/PSDepend/Public/Import-Dependency.ps1
+++ b/PSDepend/Public/Import-Dependency.ps1
@@ -1,16 +1,15 @@
-Function Test-Dependency {
+Function Import-Dependency {
     <#
     .SYNOPSIS
-        Test a specific dependency
+        Import a specific dependency
 
     .DESCRIPTION
-        Test a specific dependency.  Validates whether a dependency exists
+        Import a specific dependency, if that dependency supports it.
 
         Takes output from Get-Dependency
 
           * Runs dependency scripts depending on each dependencies type.
-          * Appends a 'DependencyExists' property indicating whether the dependency exists; alternatively
-          * Returns $True or $False if the -Quiet switch is used
+          * Imports items if supported
 
         See Get-Help about_PSDepend for more information.
 
@@ -26,9 +25,9 @@ Function Test-Dependency {
         Only test dependencies that are tagged with all of the specified Tags (-and, not -or)
 
     .EXAMPLE
-        Get-Dependency -Path C:\requirements.psd1 | Test-Dependency
+        Get-Dependency -Path C:\requirements.psd1 | Import-Dependency
 
-        Get dependencies from C:\requirements.psd1 and test whether they exist
+        Get dependencies from C:\requirements.psd1 and import them
 
     .LINK
         about_PSDepend
@@ -61,14 +60,12 @@ Function Test-Dependency {
         [validatescript({Test-Path -Path $_ -PathType Leaf -ErrorAction Stop})]
         [string]$PSDependTypePath = $(Join-Path $ModuleRoot PSDependMap.psd1),
 
-        [string[]]$Tags,
-
-        [switch]$Quiet
+        [string[]]$Tags
     )
     Begin
     {
         # This script reads a depend.psd1, installs dependencies as defined
-        Write-Verbose "Running Test-Dependency with ParameterSetName '$($PSCmdlet.ParameterSetName)' and params: $($PSBoundParameters | Out-String)"
+        Write-Verbose "Running Import-Dependency with ParameterSetName '$($PSCmdlet.ParameterSetName)' and params: $($PSBoundParameters | Out-String)"
     }
     Process
     {
@@ -120,30 +117,22 @@ Function Test-Dependency {
                     }
                     if($splat.ContainsKey('PSDependAction'))
                     {
-                        $Splat['PSDependAction'] = 'Test'
+                        $Splat['PSDependAction'] = 'Import'
                     }
                     else
                     {
-                        $Splat.add('PSDependAction','Test')
+                        $Splat.add('PSDependAction','Import')
                     }
                 }
                 else
                 {
-                    $splat = @{PSDependAction = 'Test'}
+                    $splat = @{PSDependAction = 'Import'}
                 }
 
                 #Define params for the script
                 $splat.add('Dependency', $ThisDependency)
 
-                $TestResult = . $DependencyScript @splat
-                if($Quiet)
-                {
-                    $TestResult
-                }
-                else
-                {
-                    $ThisDependency | Select -Property *, @{n='DependencyExists'; e={$TestResult}}
-                }
+                . $DependencyScript @splat
             }
         }
     }

--- a/PSDepend/Public/Install-Dependency.ps1
+++ b/PSDepend/Public/Install-Dependency.ps1
@@ -50,12 +50,10 @@ Function Install-Dependency {
     .LINK
         https://github.com/RamblingCookieMonster/PSDepend
     #>
-    [cmdletbinding( DefaultParameterSetName = 'Map',
-                    SupportsShouldProcess = $True,
+    [cmdletbinding( SupportsShouldProcess = $True,
                     ConfirmImpact='High' )]
     Param(
         [parameter( ValueFromPipeline = $True,
-                    ParameterSetName='Map',
                     Mandatory = $True)]
         [PSTypeName('PSDepend.Dependency')]
         [psobject[]]$Dependency,
@@ -83,10 +81,9 @@ Function Install-Dependency {
         {
             #Get definitions, and dependencies in this particular psd1
             $DependencyDefs = Get-PSDependScript
-            $TheseDependencyTypes = @( $Dependency.DependencyType | Sort -Unique )
+            $TheseDependencyTypes = @( $Dependency.DependencyType | Sort-Object -Unique )
 
             #Build up hash, we call each dependencytype script for applicable dependencies
-            $ToInstall = @{}
             foreach($DependencyType in $TheseDependencyTypes)
             {
                 $DependencyScript = $DependencyDefs.$DependencyType

--- a/PSDepend/Public/Install-Dependency.ps1
+++ b/PSDepend/Public/Install-Dependency.ps1
@@ -125,11 +125,11 @@ Function Install-Dependency {
 
                         if($splat.ContainsKey('PSDependAction'))
                         {
-                            $Splat['PSDependAction'] = 'Import'
+                            $Splat['PSDependAction'] = 'Install'
                         }
                         else
                         {
-                            $Splat.add('PSDependAction','Import')
+                            $Splat.add('PSDependAction','Install')
                         }
                     }
                     else

--- a/PSDepend/Public/Invoke-PSDepend.ps1
+++ b/PSDepend/Public/Invoke-PSDepend.ps1
@@ -83,9 +83,6 @@ Function Invoke-PSDepend {
         # This script reads a depend.psd1, deploys files or folders as defined
         Write-Verbose "Running Invoke-PSDepend with ParameterSetName '$($PSCmdlet.ParameterSetName)' and params: $($PSBoundParameters | Out-String)"
 
-        $RejectAll = $false
-        $ConfirmAll = $false
-
         # Do we want force?
         $InvokeParams = @{}
         if($Force)
@@ -118,15 +115,12 @@ Function Invoke-PSDepend {
             $GetPSDependParams.Add('Tags',$Tags)
         }
 
-        $DependencyScripts = Get-PSDependScript
-
         # Handle Dependencies
         $ToInstall = Get-Dependency @GetPSDependParams
 
         #TODO: Add ShouldProcess here.  Having it in Install-Dependency is bad.
         foreach($Dependency in $ToInstall)
         {
-            $Type = $Dependency.DependencyType
             $Install = $True #anti pattern! Best I could come up with to handle both prescript fail and dependencies
 
             if($Deployment.PreScripts.Count -gt 0)

--- a/PSDepend/Public/Test-Dependency.ps1
+++ b/PSDepend/Public/Test-Dependency.ps1
@@ -48,9 +48,7 @@ Function Test-Dependency {
     .LINK
         https://github.com/RamblingCookieMonster/PSDepend
     #>
-    [cmdletbinding( DefaultParameterSetName = 'Map',
-                    SupportsShouldProcess = $True,
-                    ConfirmImpact='High' )]
+    [cmdletbinding()]
     Param(
         [parameter( ValueFromPipeline = $True,
                     ParameterSetName='Map',
@@ -76,10 +74,9 @@ Function Test-Dependency {
 
         #Get definitions, and dependencies in this particular psd1
         $DependencyDefs = Get-PSDependScript
-        $TheseDependencyTypes = @( $Dependency.DependencyType | Sort -Unique )
+        $TheseDependencyTypes = @( $Dependency.DependencyType | Sort-Object -Unique )
 
-        #Build up hash, we call each dependencytype script for applicable dependencies
-        $ToTest = @{}
+        #call each dependencytype script for applicable dependencies
         foreach($DependencyType in $TheseDependencyTypes)
         {
             $DependencyScript = $DependencyDefs.$DependencyType
@@ -142,7 +139,7 @@ Function Test-Dependency {
                 }
                 else
                 {
-                    $ThisDependency | Select -Property *, @{n='DependencyExists'; e={$TestResult}}
+                    $ThisDependency | Select-Object -Property *, @{n='DependencyExists'; e={$TestResult}}
                 }
             }
         }

--- a/PSDepend/Public/Test-Dependency.ps1
+++ b/PSDepend/Public/Test-Dependency.ps1
@@ -1,0 +1,165 @@
+Function Test-Dependency {
+    <#
+    .SYNOPSIS
+        Test a specific dependency
+
+    .DESCRIPTION
+        Test a specific dependency.  Validates whether a dependency exists
+
+        Takes output from Get-Dependency
+
+          * Runs dependency scripts depending on each dependencies type.
+          * Appends a 'DependencyExists' property indicating whether the dependency exists; alternatively
+          * Returns $True or $False if the -Quiet switch is used
+
+        See Get-Help about_PSDepend for more information.
+
+    .PARAMETER Dependency
+        Dependency object from Get-Dependency.
+
+    .PARAMETER PSDependTypePath
+        Specify a PSDependMap.psd1 file that maps DependencyTypes to their scripts.
+
+        This defaults to the PSDependMap.psd1 in the PSDepend module folder
+
+    .PARAMETER Tags
+        Only test dependencies that are tagged with all of the specified Tags (-and, not -or)
+
+    .EXAMPLE
+        Get-Dependency -Path C:\requirements.psd1 | Test-Dependency
+
+        Get dependencies from C:\requirements.psd1 and test whether they exist
+
+    .LINK
+        about_PSDepend
+
+    .LINK
+        about_PSDepend_Definitions
+
+    .LINK
+        Get-Dependency
+
+    .LINK
+        Get-PSDependType
+
+    .LINK
+        Invoke-PSDepend
+
+    .LINK
+        https://github.com/RamblingCookieMonster/PSDepend
+    #>
+    [cmdletbinding( DefaultParameterSetName = 'Map',
+                    SupportsShouldProcess = $True,
+                    ConfirmImpact='High' )]
+    Param(
+        [parameter( ValueFromPipeline = $True,
+                    ParameterSetName='Map',
+                    Mandatory = $True)]
+        [PSTypeName('PSDepend.Dependency')]
+        [psobject[]]$Dependency,
+
+        [validatescript({Test-Path -Path $_ -PathType Leaf -ErrorAction Stop})]
+        [string]$PSDependTypePath = $(Join-Path $ModuleRoot PSDependMap.psd1),
+
+        [string[]]$Tags,
+
+        [switch]$Quiet
+    )
+    Begin
+    {
+        # This script reads a depend.psd1, installs dependencies as defined
+        Write-Verbose "Running Test-Dependency with ParameterSetName '$($PSCmdlet.ParameterSetName)' and params: $($PSBoundParameters | Out-String)"
+    }
+    Process
+    {
+        Write-Verbose "Dependencies:`n$($Dependency | Out-String)"
+
+        #Get definitions, and dependencies in this particular psd1
+        $DependencyDefs = Get-PSDependScript
+        $TheseDependencyTypes = @( $Dependency.DependencyType | Sort -Unique )
+
+        #Build up hash, we call each dependencytype script for applicable dependencies
+        $ToTest = @{}
+        foreach($DependencyType in $TheseDependencyTypes)
+        {
+            $DependencyScript = $DependencyDefs.$DependencyType
+            if(-not $DependencyScript)
+            {
+                Write-Error "DependencyType $DependencyType is not defined in PSDependMap.psd1"
+                continue
+            }
+            $TheseDependencies = @( $Dependency | Where-Object {$_.DependencyType -eq $DependencyType})
+
+            #Define params for the script
+            #Each dependency type can have a hashtable to splat.
+            $RawParameters = Get-Parameter -Command $DependencyScript
+            $ValidParamNames = $RawParameters.Name
+
+            if($ValidParamNames -notcontains 'PSDependAction')
+            {
+                Write-Error "No PSDependAction found on PSDependScript [$DependencyScript]. Skipping [$($Dependency.DependencyName)]"
+                continue
+            }
+
+            foreach($ThisDependency in $TheseDependencies)
+            {
+                #Parameters for dependency types.  Only accept valid params...
+                if($ThisDependency.Parameters.keys.count -gt 0)
+                {
+                    #Define params for the script
+                    #Each dependency type can have a hashtable to splat.
+                    $RawParameters = Get-Parameter -Command $DependencyScript
+                    $ValidParamNames = $RawParameters.Name
+
+                    if($ValidParamNames -notcontains 'PSDependAction')
+                    {
+                        Write-Error "No PSDependAction found on PSDependScript [$DependencyScript]. Skipping [$($ThisDependency.DependencyName)]"
+                        continue
+                    }
+
+
+                    $splat = @{}
+                    foreach($key in $ThisDependency.Parameters.keys)
+                    {
+                        if($ValidParamNames -contains $key)
+                        {
+                            $splat.Add($key, $ThisDependency.Parameters.$key)
+                        }
+                        else
+                        {
+                            Write-Warning "Parameter [$Key] with value [$($ThisDependency.Parameters.$Key)] is not a valid parameter for [$DependencyType], ignoring.  Valid params:`n[$ValidParamNames]"
+                        }
+                    }
+                    if($splat.ContainsKey('PSDependAction'))
+                    {
+                        $Splat['PSDependAction'] = 'Test'
+                    }
+                    else
+                    {
+                        $Splat.add('PSDependAction','Test')
+                    }
+                }
+                else
+                {
+                    $splat = @{PSDependAction = 'Test'}
+                }
+
+                #Define params for the script
+                $splat.add('Dependency', $ThisDependency)
+
+                $TestResult = . $DependencyScript @splat
+                if($Quiet)
+                {
+                    $TestResult
+                }
+                else
+                {
+                    $ThisDependency | Select -Property *, @{n='DependencyExists'; e={$TestResult}}
+                }
+            }
+        }
+    }
+}
+
+
+

--- a/Tests/DependFiles/dependson.depend.psd1
+++ b/Tests/DependFiles/dependson.depend.psd1
@@ -1,0 +1,15 @@
+﻿@{    
+    two = @{
+        DependencyType = 'noop'
+        DependsOn = 'one'
+    }
+
+    three= @{
+        DependencyType = 'noop'
+        DependsOn = 'two'
+    }
+    
+    one = @{
+        DependencyType = 'noop'
+    }
+}

--- a/Tests/DependFiles/filedownload.depend.psd1
+++ b/Tests/DependFiles/filedownload.depend.psd1
@@ -2,6 +2,6 @@
     'sqlite_dll' = @{
         DependencyType = 'FileDownload'
         Source = 'https://github.com/RamblingCookieMonster/PSSQLite/blob/master/PSSQLite/x64/System.Data.SQLite.dll?raw=true'
-        Target = 'C:\temp'
+        Target = 'C:\PSDependPesterTest'
     }
 }

--- a/Tests/DependFiles/git.depend.psd1
+++ b/Tests/DependFiles/git.depend.psd1
@@ -2,7 +2,7 @@
     'buildhelpers' = @{
         Name = 'https://github.com/RamblingCookieMonster/BuildHelpers.git'
         Version = 'd32a9495c39046c851ceccfb7b1a85b17d5be051'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'C:\PSDependPesterTest\buildhelpers'
     }
     'ramblingcookiemonster/PSDeploy' = 'master'
     'nightroman/Invoke-Build' = 'ac54571010d8ca5107fc8fa1a69278102c9aa077'

--- a/Tests/DependFiles/git.depend.psd1
+++ b/Tests/DependFiles/git.depend.psd1
@@ -1,0 +1,9 @@
+﻿@{
+    'buildhelpers' = @{
+        Name = 'https://github.com/RamblingCookieMonster/BuildHelpers.git'
+        Version = 'd32a9495c39046c851ceccfb7b1a85b17d5be051'
+        Target = 'C:\PSDependPesterTest'
+    }
+    'ramblingcookiemonster/PSDeploy' = 'master'
+    'nightroman/Invoke-Build' = 'ac54571010d8ca5107fc8fa1a69278102c9aa077'
+}

--- a/Tests/DependFiles/git.simple.depend.psd1
+++ b/Tests/DependFiles/git.simple.depend.psd1
@@ -1,0 +1,4 @@
+﻿@{
+    'ramblingcookiemonster/PSDeploy' = 'master'
+    'ramblingcookiemonster/BuildHelpers' = 'd32a9495c39046c851ceccfb7b1a85b17d5be051'
+}

--- a/Tests/DependFiles/git.simple.depend.psd1
+++ b/Tests/DependFiles/git.simple.depend.psd1
@@ -1,4 +1,0 @@
-﻿@{
-    'ramblingcookiemonster/PSDeploy' = 'master'
-    'ramblingcookiemonster/BuildHelpers' = 'd32a9495c39046c851ceccfb7b1a85b17d5be051'
-}

--- a/Tests/DependFiles/git.test.depend.psd1
+++ b/Tests/DependFiles/git.test.depend.psd1
@@ -1,0 +1,3 @@
+﻿@{
+    'ramblingcookiemonster/PSDeploy' = 'imaginary_branch'
+}

--- a/Tests/DependFiles/psgallerynuget.addtopath.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.addtopath.depend.psd1
@@ -1,0 +1,11 @@
+﻿@{
+    'imaginary' = @{
+        DependencyType = 'PSGalleryNuget'
+        Version = '1.2.5'
+        Target = 'C:\PSDependPesterTest'
+        AddToPath = $True
+        Parameters = @{
+            Force = $true
+        }
+    }
+}

--- a/Tests/DependFiles/psgallerynuget.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.depend.psd1
@@ -1,0 +1,10 @@
+﻿@{
+    'jenkins' = @{
+        DependencyType = 'PSGalleryNuget'
+        Version = 'latest'
+        Target = 'C:\PSDependPesterTest'
+        Parameters = @{
+            Force = $true
+        }
+    }
+}

--- a/Tests/DependFiles/psgallerynuget.sameversion.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.sameversion.depend.psd1
@@ -1,0 +1,10 @@
+﻿@{
+    'jenkins' = @{
+        DependencyType = 'PSGalleryNuget'
+        Version = '1.2.5'
+        Target = 'C:\PSDependPesterTest'
+        Parameters = @{
+            Force = $true
+        }
+    }
+}

--- a/Tests/PSDepend.Tests.ps1
+++ b/Tests/PSDepend.Tests.ps1
@@ -59,8 +59,16 @@ Describe "Get-Dependency PS$PSVersion" {
             $Dependencies.DependsOn | Should be 'DependsOn'
             $Dependencies.PreScripts | Should be 'C:\PreScripts.ps1'
             $Dependencies.PostScripts | Should be 'C:\PostScripts.ps1'
-            $Dependencies.Raw.ContainsKey('ExtendedSchema') | SHould be $True
+            $Dependencies.Raw.ContainsKey('ExtendedSchema') | Should be $True
             $Dependencies.Raw.ExtendedSchema['IsTotally'] | Should Be 'Captured'
+        }
+
+        It 'Should handle DependsOn' {
+            $Dependencies = Get-Dependency -Path $TestDepends\dependson.depend.psd1
+            @( $Dependencies ).count | Should Be 3
+            $Dependencies[0].DependencyName | Should be 'One'
+            $Dependencies[1].DependencyName | Should be 'Two'
+            $Dependencies[2].DependencyName | Should be 'THree'
         }
     }
 }

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -110,8 +110,6 @@ InModuleScope 'PSDepend' {
             Mock Push-Location {}
             Mock Pop-Location {}
             Mock Set-Location {}
-            Set-Location $SavePath
-
 
             $Dependencies = Get-Dependency @Verbose -Path "$TestDepends\git.depend.psd1"
 
@@ -127,7 +125,31 @@ InModuleScope 'PSDepend' {
             It 'Invokes the Git dependency type' {
                 Assert-MockCalled -CommandName Invoke-ExternalCommand -Times 6 -Exactly
             }
+        }
+    }
 
+    Describe "FileDownload Type PS$PSVersion" {
+
+        Context 'Installs Module' {
+            Mock Get-WebFile {
+                [pscustomobject]@{
+                    PSB = $PSBoundParameters
+                    Arg = $Args
+                }
+            }
+
+            $Dependencies = @(Get-Dependency @Verbose -Path "$TestDepends\filedownload.depend.psd1")
+
+            It 'Parses the FileDownload dependency type' {
+                $Dependencies.count | Should be 1
+                $Dependencies[0].DependencyType | Should be 'FileDownload'
+            }
+
+            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\filedownload.depend.psd1" -Force
+            
+            It 'Invokes the FileDownload dependency type' {
+                Assert-MockCalled Get-WebFile -Times 1 -Exactly
+            }
         }
     }
 }

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -7,6 +7,9 @@ Import-Module (Join-Path $ENV:BHProjectPath $ENV:BHProjectName) -Force
 
 $null = mkdir 'C:\PSDependPesterTest' -force
 
+# Maybe use a convention for describe/context/it... these are all over the place...
+# Pull requests welcome!
+
 InModuleScope 'PSDepend' {
 
     $TestDepends = Join-Path $ENV:BHProjectPath Tests\DependFiles
@@ -176,6 +179,30 @@ InModuleScope 'PSDepend' {
             It 'Invokes the Git dependency type' {
                 Assert-MockCalled -CommandName Invoke-ExternalCommand -Times 6 -Exactly
             }
+
+        }
+        Context 'Tests dependency' {
+            Mock mkdir { return $true }
+            Mock Push-Location
+            Mock Pop-Location
+            Mock Set-Location
+            Mock Invoke-ExternalCommand -ParameterFilter {$Arguments -contains 'checkout' -or $Arguments -contains 'clone'}
+            
+
+            It 'Returns $false if git repo does not exist' {
+                Mock Test-Path { return $False } -ParameterFilter {$Path -match "PSDeploy$"}
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\git.test.depend.psd1" | Test-Dependency @Verbose -Quiet )
+                $Results.count | Should be 1
+                $Results[0] | Should be $False
+            }
+
+            It 'Returns $true if git repo does exist' {
+                Mock Test-Path { return $true } -ParameterFilter {$Path -match "PSDeploy$"}
+                Mock Invoke-ExternalCommand { return 'imaginary_branch' } -ParameterFilter {$Arguments -contains 'rev-parse'}
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\git.test.depend.psd1" | Test-Dependency @Verbose -Quiet )
+                $Results.count | Should be 1
+                $Results[0] | Should be $true
+            }
         }
     }
 
@@ -229,6 +256,108 @@ InModuleScope 'PSDepend' {
                 $Results.count | Should be 1
                 $Results[0] | Should be $true
                 Assert-MockCalled -CommandName Get-WebFile -Times 0 -Exactly
+            }
+        }
+    }
+    Describe "PSGalleryNuget Type PS$PSVersion" {
+
+        Context 'Installs Modules' {
+            Mock Test-Path { Return $true } -ParameterFilter { $PathType -eq 'Container' }
+            Mock Invoke-ExternalCommand { Return $true }
+            Mock Find-NugetPackage { Return $true }
+            
+            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerynuget.depend.psd1" -Force
+
+            It 'Should execute Invoke-ExternalCommand' {
+                Assert-MockCalled Invoke-ExternalCommand -Times 1 -Exactly
+            }
+
+            It 'Should Return Mocked output' {
+                $Results | Should be $True
+            }
+        }
+
+        Context 'Same module version exists' {
+            Mock Test-Path {return $True} -ParameterFilter {$Path -match 'jenkins'}
+            Mock Invoke-ExternalCommand {}
+            Mock Import-LocalizedData {
+                [pscustomobject]@{
+                    ModuleVersion = '1.2.5'
+                }
+            } -ParameterFilter {$FileName -eq 'jenkins.psd1'}
+            Mock Find-NugetPackage {
+                [pscustomobject]@{
+                    Version = '1.2.5'
+                }
+            }
+
+            It 'Runs Import-LocalizedData and Find-NugetPackage, skips Invoke-ExternalCommand' {
+                $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerynuget.sameversion.depend.psd1" -Force -ErrorAction Stop
+
+                Assert-MockCalled Import-LocalizedData -Times 1 -Exactly
+                Assert-MockCalled Find-NugetPackage -Times 1 -Exactly
+                Assert-MockCalled Invoke-ExternalCommand -Times 0 -Exactly
+            }
+        }
+
+        Context 'Test-Dependency' {
+            It 'Returns $true when it finds an existing module' {
+                Mock Test-Path {return $True} -ParameterFilter {$Path -match 'jenkins'}
+                Mock Invoke-ExternalCommand {}
+                Mock Import-LocalizedData {
+                    [pscustomobject]@{
+                        ModuleVersion = '1.2.5'
+                    }
+                } -ParameterFilter {$FileName -eq 'jenkins.psd1'}
+                Mock Find-NugetPackage {
+                    [pscustomobject]@{
+                        Version = '1.2.5'
+                    }
+                }
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerynuget.sameversion.depend.psd1" |
+                        Test-Dependency -Quiet )
+                $Results.Count | Should be 1
+                $Results[0] | Should be $True
+            }
+
+            It "Returns `$false when it doesn't find an existing module" {
+                Mock Import-LocalizedData -ParameterFilter {$FileName -eq 'jenkins.psd1'}
+                Mock Find-NugetPackage {
+                    [pscustomobject]@{
+                        Version = '1.2.5'
+                    }
+                }
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerynuget.sameversion.depend.psd1" |
+                        Test-Dependency -Quiet )
+                $Results.Count | Should be 1
+                $Results[0] | Should be $False
+            }
+
+            It "Returns `$false when it finds an existing module with a lower version" {
+                Mock Find-NugetPackage {
+                    [pscustomobject]@{
+                        Version = '1.2.5'
+                    }
+                }
+                Mock Import-LocalizedData {
+                    [pscustomobject]@{
+                        ModuleVersion = '1.2.4'
+                    }
+                } -ParameterFilter {$FileName -eq 'jenkins.psd1'}
+
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerynuget.sameversion.depend.psd1" |
+                        Test-Dependency -Quiet )
+                $Results.Count | Should be 1
+                $Results[0] | Should be $False
+            }
+        }
+
+        Context 'Misc' {
+            It 'Adds folder to path when specified' {
+                Mock Invoke-ExternalCommand {} {$True}
+                $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerynuget.addtopath.depend.psd1" -Force -ErrorAction Stop
+                $env:PSModulePath -split ";" -contains $SavePath | Should Be $True
+                $ENV:PSModulePath = $ExistingPSModulePath
             }
         }
     }

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -96,6 +96,40 @@ InModuleScope 'PSDepend' {
             }
         }
     }
+
+    Describe "Git Type PS$PSVersion" {
+
+        Context 'Installs Module' {
+            Mock Invoke-ExternalCommand {
+                [pscustomobject]@{
+                    PSB = $PSBoundParameters
+                    Arg = $Args
+                }
+            }
+            Mock mkdir { return $true }
+            Mock Push-Location {}
+            Mock Pop-Location {}
+            Mock Set-Location {}
+            Set-Location $SavePath
+
+
+            $Dependencies = Get-Dependency @Verbose -Path "$TestDepends\git.depend.psd1"
+
+            It 'Parses the Git dependency type' {
+                $Dependencies.count | Should be 3
+                ( $Dependencies | Where {$_.DependencyType -eq 'Git'} ).Count | Should Be 3
+                ( $Dependencies | Where {$_.DependencyName -like 'nightroman/Invoke-Build'}).Version | Should be 'ac54571010d8ca5107fc8fa1a69278102c9aa077'
+                ( $Dependencies | Where {$_.DependencyName -like 'ramblingcookiemonster/PSDeploy'}).Version | Should be 'master'
+            }
+
+            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\git.depend.psd1" -Force
+            
+            It 'Invokes the Git dependency type' {
+                Assert-MockCalled -CommandName Invoke-ExternalCommand -Times 6 -Exactly
+            }
+
+        }
+    }
 }
 
 Remove-Item C:\PSDependPesterTest -Force -Recurse


### PR DESCRIPTION
* Add Test-Dependency and Import-Dependency functions
* Add PSDependAction parameter to dependency scripts.  Test-Dependency, Install-Dependency, and Import-Dependency specify Test, Install, or Import, respectively. Authors implement test, install, import, and perhaps others in their dependency scripts
* Wrote some sloppy (content and organization) tests - PRs welcome!
* Fixed a variety of bugs discovered while writing tests.  Maybe write tests from the start...
* Add smarter 'tests' to git dependency type.  Now checks branch or commit against specified version.  Still need to add logic to fetch and checkout (no clone) if we find existing.  Or just kill it and re-clone/checkout...
* Added several wrapper functions to help with testing (e.g. to mock git.exe, .net things)
* Fixed some PSScriptAnalyzer complaints
