### PR TITLE
Update Get-Parameter.ps1 - sort breaks powershell on linux

### DIFF
--- a/PSDepend/Private/Get-Parameter.ps1
+++ b/PSDepend/Private/Get-Parameter.ps1
@@ -165,7 +165,7 @@ Function Get-Parameter {
             $ParameterNames = $Parameters.Keys + $Aliases
             foreach ($p in $($Parameters.Keys)) {
                $short = "^"
-               $aliases = @($p) + @($Parameters.$p.Aliases) | sort { $_.Length }
+               $aliases = @($p) + @($Parameters.$p.Aliases) | sort-object { $_.Length }
                $shortest = "^" + @($aliases)[0]
 
                foreach($name in $aliases) {


### PR DESCRIPTION
Using sort in powershell breaks psDepend in Linux/osX as sort is a built-in command. 

Using sort-object instead resolves the issue. 