### PR TITLE
fixing add to path when relative

### DIFF
--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -218,7 +218,7 @@ if($PSDependAction -contains 'Install')
         if($Dependency.AddToPath)
         {
             Write-Verbose "Setting PSModulePath to`n$($Scope, $env:PSModulePath -join ';' | Out-String)"
-            Add-ToItemCollection -Reference Env:\PSModulePath -Item $Scope
+            Add-ToItemCollection -Reference Env:\PSModulePath -Item (Get-Item $Scope).FullName
         }
     }
 }


### PR DESCRIPTION
Hi @RamblingCookieMonster , this is a fix for #33 

When a relative path is specified for the target of the PSGalleryModule script, the download saves at the right place, but the entry added to `$Env:PSModulePath` only uses the relative path (instead of resolving the absolute one).

A quick `(Get-Item $scope).FullName` sorts it out for me, let me know if there's unforeseen potential side effects.

This PR should automagically fix my build of SampleModule here once released: https://ci.appveyor.com/project/gaelcolas/samplemodule