### PR TITLE
Patch for PreScripts and PostScripts features

### DIFF
--- a/PSDepend/PSDependScripts/FileSystem.ps1
+++ b/PSDepend/PSDependScripts/FileSystem.ps1
@@ -13,7 +13,7 @@
             Target: The folder to copy the source to.  If the source is a file, we adjust this in Robocopy to append the source folder name.
             Source: The source folder or file to copy
 
-    .PARAMETER Deployment
+    .PARAMETER Dependency
         Dependency to run
 
     .PARAMETER PSDependAction

--- a/PSDepend/Private/Get-TaggedDependency.ps1
+++ b/PSDepend/Private/Get-TaggedDependency.ps1
@@ -4,7 +4,7 @@
         [string[]]$Tags
     )
 
-    # Only return deployment with all specified tags
+    # Only return dependency with all specified tags
     foreach($Depend in $Dependency)
     {
         $Include = $False

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -56,7 +56,7 @@ function Get-Dependency {
                 }
             }
 
-        We use the same default DeploymentTypes for this advanced syntax
+        We use the same default DependencyTypes for this advanced syntax
 
         Global options:
            @{

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -163,7 +163,10 @@ function Get-Dependency {
         }
         
         # Inject variables
-        if( $Name -eq 'Target' -or $Name -eq 'Source')
+        if( $Name -eq 'Target' -or
+            $Name -eq 'Source' -or
+            $Name -eq 'PreScripts' -or
+            $Name -eq 'PostScripts')
         {
             $Output = Inject-Variable $Output
         }

--- a/PSDepend/Public/Invoke-PSDepend.ps1
+++ b/PSDepend/Public/Invoke-PSDepend.ps1
@@ -223,21 +223,21 @@ Function Invoke-PSDepend {
                                         "Processing dependency" ))
             {
                 $PreScriptSuccess = $True #anti pattern! Best I could come up with to handle both prescript fail and dependencies
-                if($DoInstall -and $Deployment.PreScripts.Count -gt 0)
+                if($DoInstall -and $Dependency.PreScripts.Count -gt 0)
                 {
                     $ExistingEA = $ErrorActionPreference
                     $ErrorActionPreference = 'Stop'
-                    foreach($script in $Dependency.Prescripts)
+                    foreach($script in $Dependency.PreScripts)
                     {
                         Try
                         {
-                            Write-Verbose "Invoking pre script: [$Script]"
-                            . $Script
+                            Write-Verbose "Invoking pre script: [$script]"
+                            . $script
                         }
                         Catch
                         {
                             $PreScriptSuccess = $False
-                            "Skipping installation due to failed pre script: [$Script]"
+                            "Skipping installation due to failed pre script: [$script]"
                             Write-Error $_
                         }
                     }

--- a/PSDepend/Public/Invoke-PSDepend.ps1
+++ b/PSDepend/Public/Invoke-PSDepend.ps1
@@ -256,12 +256,12 @@ Function Invoke-PSDepend {
                     }
                 }
 
-                if($DoInstall -and $Dependency.PostScript.Count -gt 0)
+                if($DoInstall -and $Dependency.PostScripts.Count -gt 0)
                 {
-                    foreach($script in $Deployment.PostScript)
+                    foreach($script in $Dependency.PostScripts)
                     {
-                        Write-Verbose "Invoking post script: $($Script)"
-                        . $Script
+                        Write-Verbose "Invoking post script: $($script)"
+                        . $script
                     }
                 }
             }

--- a/PSDepend/en-US/about_PSDepend.help.txt
+++ b/PSDepend/en-US/about_PSDepend.help.txt
@@ -21,7 +21,7 @@ DETAILED DESCRIPTION
                                 The default type is PSGalleryModule.
                                 This is extensible.
 
-        Deployment Script:      These are scripts associated to a particular dependency type.
+        Dependency Script:      These are scripts associated to a particular dependency type.
                                 They tell PSDepend how to install a dependency type.
                                 All should accept a 'Dependency' parameter.
                                 For example, the PSGalleryModule script uses PowerShellGet to find


### PR DESCRIPTION
Hi @RamblingCookieMonster this a patch for to fix #36 and #37.

From now these two features are available and working.
Causes were some typos in code.

I have also included `PreScripts` and `PostScripts` into the logic for _variable injection_, so you can use the `$PWD`, `$DependencyFolder` etc also in these properties.

Finally, I fixed some documentation typos.

All tests passes.