### PR TITLE
support Module extraction for git type

### DIFF
--- a/PSDepend/PSDepend.psd1
+++ b/PSDepend/PSDepend.psd1
@@ -4,7 +4,7 @@
 RootModule = 'PSDepend.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.49'
+ModuleVersion = '0.1.56'
 
 # ID used to uniquely identify this module
 GUID = '63ea9e2a-320d-43ff-a11a-4930ca03cce6'
@@ -58,7 +58,7 @@ PowerShellVersion = '3.0'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = '*'
+FunctionsToExport = @('Get-Dependency','Get-PSDependScript','Get-PSDependType','Import-Dependency','Install-Dependency','Invoke-DependencyScript','Invoke-PSDepend','Test-Dependency')
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'

--- a/PSDepend/PSDepend.psd1
+++ b/PSDepend/PSDepend.psd1
@@ -58,7 +58,7 @@ PowerShellVersion = '3.0'
 # NestedModules = @()
 
 # Functions to export from this module
-FunctionsToExport = @('Get-Dependency','Get-PSDependScript','Get-PSDependType','Import-Dependency','Install-Dependency','Invoke-DependencyScript','Invoke-PSDepend','Test-Dependency')
+FunctionsToExport = '*'
 
 # Cmdlets to export from this module
 CmdletsToExport = '*'

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -173,17 +173,18 @@ if($GottaInstall -and !$ExtractProject)
 }
 elseif($GottaInstall -and $ExtractProject) {
     $OutPath = Join-Path ([System.IO.Path]::GetTempPath()) ([guid]::NewGuid().guid)
-    $RepoFolder = Join-Path -Path $OutPath -ChildPath $Name
+    $RepoFolder = Join-Path -Path $OutPath -ChildPath $GitName
 
     $null = New-Item -ItemType Directory -Path $OutPath -Force
     Push-Location $OutPath
     
-    Write-Verbose -Message "Cloning dependency [$Name] with git from [$($Target)]"
+    Write-Verbose -Message "Cloning dependency [$GitName] with git from [$($Target)]"
     Invoke-ExternalCommand git 'clone', $Name
 
-    Push-Location $Name
-    Write-Verbose -Message "Checking out [$Version] of [$Name] from [$RepoFolder]"
+    Push-Location $GitName
+    Write-Verbose -Message "Checking out [$Version] of [$GitName] from [$RepoFolder]"
     Invoke-ExternalCommand git 'checkout', $Version
+    Pop-Location
 
     if($ExtractProject)
     {
@@ -194,7 +195,7 @@ elseif($GottaInstall -and $ExtractProject) {
     {
         [string[]]$ToCopy = $RepoFolder
     }
-
+    Pop-Location
 
     #TODO: Implement test and import PSDependActions.
     if(-not (Test-Path $Target))

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -186,15 +186,9 @@ elseif($GottaInstall -and $ExtractProject) {
     Invoke-ExternalCommand git 'checkout', $Version
     Pop-Location
 
-    if($ExtractProject)
-    {
-        $ProjectDetails = Get-ProjectDetail -Path $RepoFolder
-        [string[]]$ToCopy = $ProjectDetails.Path
-    }
-    else
-    {
-        [string[]]$ToCopy = $RepoFolder
-    }
+
+    $ProjectDetails = Get-ProjectDetail -Path $RepoFolder
+    [string[]]$ToCopy = $ProjectDetails.Path
     Pop-Location
 
     #TODO: Implement test and import PSDependActions.

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -196,7 +196,7 @@ if($PSDependAction -contains 'Install')
     if($Dependency.AddToPath)
     {
         Write-Verbose "Setting PSModulePath to`n$($Target, $env:PSModulePath -join ';' | Out-String)"
-        Add-ToItemCollection -Reference Env:\PSModulePath -Item $Target
+        Add-ToItemCollection -Reference Env:\PSModulePath -Item (Get-Item $Target).FullName
     }
 }
 


### PR DESCRIPTION
* Allows to extract a Module (similarly to github type) from a git type
* Fixed a 'bug' in PSGalleryNuget & git to Resolve Full Path of target before adding to path (problem when Path is relative in the dependency file).

Just remembered that I need to update the help. Will follow up later (either new PR if merged, or commit to this PR).
