### PR TITLE
fix: ensure the correct version of a module is imported

### DIFF
--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -160,7 +160,7 @@ if($Existing)
     {
         Write-Verbose "You have the requested version [$Version] of [$Name]"
         # Conditional import
-        Import-PSDependModule -Name $ModuleName -Action $PSDependAction
+        Import-PSDependModule -Name $ModuleName -Action $PSDependAction -Version $ExistingVersion
 
         if($PSDependAction -contains 'Test')
         {
@@ -178,7 +178,7 @@ if($Existing)
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
 
         # Conditional import
-        Import-PSDependModule -Name $ModuleName -Action $PSDependAction
+        Import-PSDependModule -Name $ModuleName -Action $PSDependAction -Version $ExistingVersion
 
         if($PSDependAction -contains 'Test')
         {
@@ -224,4 +224,5 @@ if($PSDependAction -contains 'Install')
 }
 
 # Conditional import
-Import-PSDependModule -Name $ModuleName -Action $PSDependAction
+$importVs = $params['RequiredVersion']
+Import-PSDependModule -Name $ModuleName -Action $PSDependAction -Version $importVs

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -125,7 +125,7 @@ if(Test-Path $ModulePath)
     {
         Write-Verbose "You have the requested version [$Version] of [$Name]"
         # Conditional import
-        Import-PSDependModule -Name $ModulePath -Action $PSDependAction
+        Import-PSDependModule -Name $ModulePath -Action $PSDependAction -Version $ExistingVersion
         if($PSDependAction -contains 'Test')
         {
             return $True
@@ -141,7 +141,7 @@ if(Test-Path $ModulePath)
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"
         # Conditional import
-        Import-PSDependModule -Name $ModulePath -Action $PSDependAction
+        Import-PSDependModule -Name $ModulePath -Action $PSDependAction -Version $ExistingVersion
         if($PSDependAction -contains 'Test')
         {
             return $True
@@ -201,4 +201,7 @@ if($PSDependAction -contains 'Install')
 }
 
 # Conditional import
-Import-PSDependModule -Name $ModulePath -Action $PSDependAction
+$importVs = if ($Version -and $Version -notlike 'latest') {
+    $Version
+}
+Import-PSDependModule -Name $ModulePath -Action $PSDependAction -Version $importVs

--- a/PSDepend/Private/Import-PSDependModule.ps1
+++ b/PSDepend/Private/Import-PSDependModule.ps1
@@ -2,14 +2,23 @@
     [cmdletbinding()]
     param (
         [string[]]$Name = $ModulePath,
-        $Action = $PSDependAction
+        $Action = $PSDependAction,
+        [string] $Version
     )
     if($PSDependAction -contains 'Import')
     {
         foreach($Mod in $Name)
         {
             Write-Verbose "Importing [$Mod]"
-            Import-Module -Name $Mod -Scope Global -Force 
+            $importParams = @{
+                Name = $Mod
+                Scope = 'Global'
+                Force = $true
+            }
+            if ($Version -and $Version -ne 'latest') {
+                $importParams.add('RequiredVersion',$Version)
+            }
+            Import-Module @importParams
         }
     }
 }


### PR DESCRIPTION
Without specifying a `RequiredVersion` for `Import-Module`, powershell will import the latest version (see [here](https://info.sapien.com/index.php/scripting/scripting-modules/which-version-does-import-module-import) for details).

We don't want that - we want to ensure the exact version in the `requirements.psd1` is imported.