### PR TITLE
improve perf - remove redundant call to Get-PSRepository

### DIFF
--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -117,12 +117,6 @@ if(-not (Get-PackageProvider -Name Nuget))
 
 Write-Verbose -Message "Getting dependency [$name] from PowerShell repository [$Repository]"
 
-# Validate that $target has been setup as a valid PowerShell repository
-$validRepo = Get-PSRepository -Name $Repository -Verbose:$false -ErrorAction SilentlyContinue
-if (-not $validRepo) {
-    Write-Error "[$Repository] has not been setup as a valid PowerShell repository."
-    return
-}
 
 $params = @{
     Name = $Name

--- a/Tests/DependFiles/psgallerymodule.missingrepo.depend.psd1
+++ b/Tests/DependFiles/psgallerymodule.missingrepo.depend.psd1
@@ -1,0 +1,8 @@
+﻿@{
+    'jenkins' = @{
+        Version = 'latest'
+        Parameters = @{
+            Repository = 'Blah'
+        }
+    }
+}

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -29,7 +29,6 @@ InModuleScope 'PSDepend' {
 
         Context 'Installs Modules' {
             Mock Install-Module { Return $true }
-            Mock Get-PSRepository { Return $true }
             
             $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.depend.psd1" -Force
 
@@ -44,7 +43,6 @@ InModuleScope 'PSDepend' {
 
         Context 'Saves Modules' {
             Mock Save-Module { Return $true }
-            Mock Get-PSRepository { Return $true }
             
             $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\savemodule.depend.psd1" -Force
 
@@ -58,11 +56,10 @@ InModuleScope 'PSDepend' {
         }
 
         Context 'Repository does not Exist' {
-            Mock Install-Module {}
-            Mock Get-PSRepository { Return $false }
+            Mock Install-Module { throw "Unable to find repository 'Blah'" } -ParameterFilter { $Repository -eq 'Blah'}
 
             It 'Throws because Repository could not be found' {
-                $Results = { Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.depend.psd1" -Force -ErrorAction Stop }
+                $Results = { Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.missingrepo.depend.psd1" -Force -ErrorAction Stop }
                 $Results | Should Throw
             }
         }
@@ -142,7 +139,6 @@ InModuleScope 'PSDepend' {
 
         Context 'Imports dependencies' {
             It 'Runs Import-Module when import is specified' {
-                Mock Get-PSRepository { Return $true }
                 Mock Install-Module {}
                 Mock Import-Module
                 $Results = Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.depend.psd1" | Import-Dependency @Verbose
@@ -153,7 +149,6 @@ InModuleScope 'PSDepend' {
 
         Context 'Misc' {
             It 'Adds folder to path when specified' {
-                Mock Get-PSRepository { Return $true }
                 Mock Save-Module {$True}
                 $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.addtopath.depend.psd1" -Force -ErrorAction Stop
                 $env:PSModulePath -split ";" -contains $SavePath | Should Be $True


### PR DESCRIPTION
The existing PS commands that accept a repo (eg Install-Module)
will already throw a message saying that the repo supplied cannot
be found.

Calling `Get-PSRepository` for *each* PS repository takes approx.
3 seconds.

So given a requirement.psd1 file with 2 repositories, 6s will be
spent validating the repo exists. This time is a waste PS already
is checking for this condition.