### PR TITLE
Remove .exe dependency for Git and allow Repository to be $Null to rely on registered ones

### DIFF
--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -5,7 +5,7 @@
     .DESCRIPTION
         Clone a git repository
 
-        Note: We require git.exe in your path
+        Note: We require git in your path
 
         Relevant Dependency metadata:
             DependencyName (Key): Git URL
@@ -114,9 +114,9 @@ else # Target exists
     $GottaTest = $True
 }
 
-if(-not (Get-Command git.exe -ErrorAction SilentlyContinue))
+if(-not (Get-Command git -ErrorAction SilentlyContinue))
 {
-    Write-Error "Git dependency type requires git.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's GitPath.  Skipping [$DependencyName]"
+    Write-Error "Git dependency type requires git.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's GitPath.  Skipping [$DependencyName]"
 }
 
 $Version = $Dependency.Version

--- a/PSDepend/PSDependScripts/GitHub.ps1
+++ b/PSDepend/PSDependScripts/GitHub.ps1
@@ -5,7 +5,7 @@
     .DESCRIPTION
         EXPERIMENTAL: Download a GitHub repository
 
-        The Git dependency type requires git.exe.  The FileDownload type would just pull an archive down.
+        The Git dependency type requires git.  The FileDownload type would just pull an archive down.
         This type will...
             download a repository via HTTP,
             extract it,

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -68,6 +68,7 @@ param(
     [PSTypeName('PSDepend.Dependency')]
     [psobject[]]$Dependency,
 
+    [AllowNull()]
     [string]$Repository = 'PSGallery', # From Parameters...
 
     [switch]$Import,
@@ -117,18 +118,24 @@ if(-not (Get-PackageProvider -Name Nuget))
 
 Write-Verbose -Message "Getting dependency [$name] from PowerShell repository [$Repository]"
 
-# Validate that $target has been setup as a valid PowerShell repository
-$validRepo = Get-PSRepository -Name $Repository -Verbose:$false -ErrorAction SilentlyContinue
-if (-not $validRepo) {
-    Write-Error "[$Repository] has not been setup as a valid PowerShell repository."
-    return
+# Validate that $target has been setup as a valid PowerShell repository,
+#   but allow to rely on all PS repos registered.
+if($Repository) {
+    $validRepo = Get-PSRepository -Name $Repository -Verbose:$false -ErrorAction SilentlyContinue
+        if (-not $validRepo) {
+            Write-Error "[$Repository] has not been setup as a valid PowerShell repository."
+            return
+        }
 }
 
 $params = @{
     Name = $Name
-    Repository = $Repository
     Verbose = $VerbosePreference
     Force = $True
+}
+
+if($Repository) {
+    $params.Add('Repository',$Repository)
 }
 
 if( $Version -and $Version -ne 'latest')

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -160,7 +160,12 @@ if($Existing)
     Write-Verbose "Found existing module [$Name]"
     # Thanks to Brandon Padgett!
     $ExistingVersion = $Existing | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum
-    $GalleryVersion = Find-Module -Name $Name -Repository $Repository | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum
+    $FindModuleParams = @{Name = $Name}
+    if($Repository) {
+        $FindModuleParams.Add('Repository',$Repository)
+    }
+    
+    $GalleryVersion = Find-Module @FindModuleParams | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum
 
     # Version string, and equal to current
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)

--- a/PSDepend/en-US/about_PSDepend.help.txt
+++ b/PSDepend/en-US/about_PSDepend.help.txt
@@ -39,7 +39,7 @@ DETAILED DESCRIPTION
                             If we don't find it... Look in the path specified in PSDepend\PSDepend.Config's NugetPath. Default is PSDepend\nuget.exe
                                 If we don't find it there, we download to that path
                                 If we do find it there, we add the parent container to $ENV:Path
-      * Git: Requires git.exe in your path, or in the file path specified in PSDepend\PSDepend.Config's GitPath
+      * Git: Requires git in your path, or in the file path specified in PSDepend\PSDepend.Config's GitPath
       * Npm: Requires npm in your path
                             
     Example use (*.PSDepend.ps1)

--- a/PSDepend/en-US/about_PSDepend_Definitions.help.txt
+++ b/PSDepend/en-US/about_PSDepend_Definitions.help.txt
@@ -127,7 +127,7 @@ DETAILED DESCRIPTION
     This file includes a few configurations for PSDepend:
         
         NugetPath: Path to a nuget.exe, if it's not in your path.  If it's not found in either spot, we download to this
-        GitPath: Path to a git.exe, if it's not in your path.  We do not resolve this dependency for you (yet).
+        GitPath: Path to a git, if it's not in your path.  We do not resolve this dependency for you (yet).
 
     Dependency type map: PSDependMap.psd1
     =====================================


### PR DESCRIPTION
This is a fix for #47, #55.

This is a non-breaking change.
This will remove the Repository parameter to the Install/Find/Save module calls, effectively relying on the currently registered PSRepositories. (I still think that should be default behaviour, but it would then be a breaking change).

I'm aware there's a few PR before this one, that will create conflicts (namely #58, #57, #54, #52).
Feel free to hit me up when/if merged and I can rebase and adapt.

Gael