### PR TITLE
Non-Windows Platform Support for GitHub Script

### DIFF
--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -37,7 +37,7 @@
     }
 
     Noop = @{
-        Script = 'noop.ps1'
+        Script = 'Noop.ps1'
         Description = 'Display parameters that a depends script would receive. Use for testing and validation.'
     }
 


### PR DESCRIPTION
That's what I needed to change to make the GitHub script work with PowerShellCore (6) on Linux. Please review and comment.

+ OS dependent installation paths
+ ZIP extraction for other platforms
~ Target description
~ Alias removed, bug fixed
~ File name capitalization