### PR TITLE
Use capitalized version of Noop to avoid issues on linux

### DIFF
--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -37,7 +37,7 @@
     }
 
     Noop = @{
-        Script = 'noop.ps1'
+        Script = 'Noop.ps1'
         Description = 'Display parameters that a depends script would receive. Use for testing and validation.'
     }
 


### PR DESCRIPTION
Use `Noop.ps1` instead of `noop.ps1` to avoid issues on case-sensitive file systems.

Fixes #74 