### PR TITLE
WIP: Add supported platforms handling

### DIFF
--- a/PSDepend/PSDepend.psd1
+++ b/PSDepend/PSDepend.psd1
@@ -4,7 +4,7 @@
 RootModule = 'PSDepend.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.1.63'
+ModuleVersion = '0.2.0'
 
 # ID used to uniquely identify this module
 GUID = '63ea9e2a-320d-43ff-a11a-4930ca03cce6'

--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -16,7 +16,6 @@
         }
     }
 
-
 #Get nuget dependecy file if we don't have it
     Get-Content $ModuleRoot\PSDepend.Config |
         Where-Object {$_ -and $_ -notmatch "^\s*#"} |

--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -27,6 +27,8 @@
             $Value = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Value)
             Set-Variable -Name $Name -Value $Value
         }
-    BootStrap-Nuget -NugetPath $NuGetPath
+    if(Test-PlatformSupport -Support 'windows') {
+        BootStrap-Nuget -NugetPath $NuGetPath
+    }
 
 Export-ModuleMember -Function $Public.Basename

--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -32,7 +32,7 @@
 
     GitHub = @{
         Script = 'GitHub.ps1'
-        Description = 'EXPERIMENTAL: Download and extract a GitHub repo'
+        Description = 'Download and extract a GitHub repo'
         Supports = 'windows', 'core', 'macos', 'linux'
     }
 

--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -2,14 +2,14 @@
 # Top level node is the dependency name
 #   Script is the script to run. These are stored in \PSDepend\PSDependScripts
 #   Description is a quick description of the dependency script
-#   Supports is a way to filter supported platforms:  core, windows, macos
+#   Supports is a way to filter supported platforms:  core, windows, macos, linux
 
 # In some cases, it may be beneficial to include 'aliases'.  Just add nodes for these.
 @{
     Command = @{
         Script = 'Command.ps1'
         Description = 'Invoke a command in PowerShell'
-        Supports = 'core', 'macos', 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     FileDownload = @{
@@ -33,31 +33,31 @@
     GitHub = @{
         Script = 'GitHub.ps1'
         Description = 'EXPERIMENTAL: Download and extract a GitHub repo'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     Npm = @{
         Script = 'Npm.ps1'
         Description = 'Install a node package'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     Noop = @{
         Script = 'Noop.ps1'
         Description = 'Display parameters that a depends script would receive. Use for testing and validation'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     Package = @{
         Script = 'Package.ps1'
         Description = 'EXPERIMENTAL: Install a package via PackageManagement Install-Package'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     PSGalleryModule = @{
         Script= 'PSGalleryModule.ps1'
         Description = 'Install a PowerShell module from the PowerShell Gallery'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     PSGalleryNuget = @{
@@ -69,6 +69,6 @@
     Task = @{
         Script = 'Task.ps1'
         Description = 'Support dependencies by handling simple tasks'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 }

--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -2,62 +2,73 @@
 # Top level node is the dependency name
 #   Script is the script to run. These are stored in \PSDepend\PSDependScripts
 #   Description is a quick description of the dependency script
+#   Supports is a way to filter supported platforms:  core, windows, macos
 
 # In some cases, it may be beneficial to include 'aliases'.  Just add nodes for these.
 @{
-
     Command = @{
-        Script= 'Command.ps1'
+        Script = 'Command.ps1'
         Description = 'Invoke a command in PowerShell'
+        Supports = 'core', 'macos', 'windows'
     }
 
     FileDownload = @{
-        Script= 'FileDownload.ps1'
+        Script = 'FileDownload.ps1'
         Description = 'Download a file'
+        Supports = 'windows'
     }
 
     FileSystem = @{
         Script = 'FileSystem.ps1'
         Description = 'Copy a file or folder'
+        Supports = 'windows'
     }
 
     Git = @{
         Script = 'Git.ps1'
         Description = 'Clone a git repository'
+        Supports = 'windows'
     }
 
     GitHub = @{
         Script = 'GitHub.ps1'
         Description = 'EXPERIMENTAL: Download and extract a GitHub repo'
+        Supports = 'windows'
     }
 
     Npm = @{
         Script = 'Npm.ps1'
         Description = 'Install a node package'
+        Supports = 'windows'
     }
 
     Noop = @{
         Script = 'Noop.ps1'
-        Description = 'Display parameters that a depends script would receive. Use for testing and validation.'
+        Description = 'Display parameters that a depends script would receive. Use for testing and validation'
+        Supports = 'windows'
     }
 
     Package = @{
         Script = 'Package.ps1'
         Description = 'EXPERIMENTAL: Install a package via PackageManagement Install-Package'
+        Supports = 'windows'
     }
 
     PSGalleryModule = @{
         Script= 'PSGalleryModule.ps1'
-        Description = 'Install a PowerShell module from the PowerShell Gallery.'
+        Description = 'Install a PowerShell module from the PowerShell Gallery'
+        Supports = 'windows'
     }
 
     PSGalleryNuget = @{
         Script = 'PSGalleryNuget.ps1'
         Description = 'Install a PowerShell module from the PowerShell Gallery without the PowerShellGet dependency'
+        Supports = 'windows'
     }
 
     Task = @{
         Script = 'Task.ps1'
-        Description = 'Support dependencies by handling simple tasks.'
+        Description = 'Support dependencies by handling simple tasks'
+        Supports = 'windows'
     }
 }

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -133,8 +133,8 @@ if($GottaTest)
 {
     Push-Location
     Set-Location $RepoPath
-    $Branch = Invoke-ExternalCommand git -Arguments (echo rev-parse --abbrev-ref HEAD) -Passthru
-    $Commit = Invoke-ExternalCommand git -Arguments (echo rev-parse HEAD) -Passthru
+    $Branch = Invoke-ExternalCommand git -Arguments (Write-Output rev-parse --abbrev-ref HEAD) -Passthru
+    $Commit = Invoke-ExternalCommand git -Arguments (Write-Output rev-parse HEAD) -Passthru
     Pop-Location
     if($Version -eq $Branch -or $Version -eq $Commit)
     {

--- a/PSDepend/PSDependScripts/GitHub.ps1
+++ b/PSDepend/PSDependScripts/GitHub.ps1
@@ -340,7 +340,7 @@ if($ShouldInstall)
         :nullcheck while($GitHubVersion -Eq $null)
         {
             $Page++
-            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+            [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
             $GitHubTags = Invoke-RestMethod -Uri "https://api.github.com/repos/$DependencyID/tags?per_page=100&page=$Page"
 
             if($GitHubTags)

--- a/PSDepend/PSDependScripts/GitHub.ps1
+++ b/PSDepend/PSDependScripts/GitHub.ps1
@@ -251,6 +251,10 @@ if($DependencyTarget)
     {
         $TargetPath = $AllUsersPath
     }
+    else
+    {
+        $TargetPath = $DependencyTarget
+    }
 }
 else
 {

--- a/PSDepend/PSDependScripts/Npm.ps1
+++ b/PSDepend/PSDependScripts/Npm.ps1
@@ -77,7 +77,7 @@ param (
         }
         If (-not (Test-Path $Target) -and $PSDependAction -contains 'Install') {
             Write-Verbose "Creating folder [$Target] for node module dependency [$Name]"
-            $null = mkdir $Target -Force
+            $null = New-Item -ItemType directory -Path  $Target -Force
         }
     }
 #endregion Extract Dependency Data

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -122,8 +122,6 @@ if(-not (Get-PackageProvider -Name Nuget))
 }
 
 Write-Verbose -Message "Getting dependency [$name] from PowerShell repository [$Repository]"
-
-
 $params = @{
     Name = $Name
     Repository = $Repository

--- a/PSDepend/PSDependScripts/Package.ps1
+++ b/PSDepend/PSDependScripts/Package.ps1
@@ -98,7 +98,7 @@ if($PSBoundParameters.ContainsKey('ProviderName'))
 }
 else # Pick providername from this packagesource
 {
-    $ThisProvider = $PackageSources | Where {$_.Name -eq $Source} | Select -ExpandProperty ProviderName
+    $ThisProvider = $PackageSources | Where-Object {$_.Name -eq $Source} | Select-Object -ExpandProperty ProviderName
 }
 
 $GetParam = @{

--- a/PSDepend/Private/Add-ToItemCollection.ps1
+++ b/PSDepend/Private/Add-ToItemCollection.ps1
@@ -6,14 +6,14 @@
         [switch]$Append
     )
 
-    $Existing = ( Get-Item -Path $Reference | Select -ExpandProperty Value ) -split $Delimiter | Where {$_ -ne $Item}
+    $Existing = ( Get-Item -Path $Reference ).Value -split $Delimiter | Where-Object {$_ -ne $Item}
     if($Append)
     {
-        $ToAdd = ( @($Existing) + $Item | Select -Unique ) -join $Delimiter
+        $ToAdd = ( @($Existing) + $Item | Select-Object -Unique ) -join $Delimiter
     }
     else
     {
-        $ToAdd = ( @($Item) + @($Existing) | Select -Unique ) -join $Delimiter
+        $ToAdd = ( @($Item) + @($Existing) | Select-Object -Unique ) -join $Delimiter
     }
     Set-Item -Path $Reference -Value $ToAdd
 }

--- a/PSDepend/Private/Add-ToPsModulePathIfRequired.ps1
+++ b/PSDepend/Private/Add-ToPsModulePathIfRequired.ps1
@@ -25,6 +25,6 @@ function Add-ToPsModulePathIfRequired {
         }
         
         Write-Verbose "Setting PSModulePath to`n$($path, $env:PSModulePath -join ';' | Out-String)"
-        Add-ToItemCollection -Reference Env:\PSModulePath -Item (Get-Item $path).FullName
+        Add-ToItemCollection -Reference Env:\PSModulePath -Item (Get-Item $path -Force).FullName
     }
 }

--- a/PSDepend/Private/Get-Hash.ps1
+++ b/PSDepend/Private/Get-Hash.ps1
@@ -125,7 +125,7 @@
                 foreach($Type in $Algorithm) {                
                 
                     [string]$hash = -join ([Security.Cryptography.HashAlgorithm]::Create( $Type ).ComputeHash( $stream ) | 
-                        ForEach { "{0:x2}" -f $_ })
+                        ForEach-Object { "{0:x2}" -f $_ })
                 
                     $null = $stream.Seek(0,0)
                 
@@ -142,7 +142,7 @@
 
                 foreach($Type in $Algorithm) {                
                     [string]$hash = -join ([Security.Cryptography.HashAlgorithm]::Create( $Type ).ComputeHash( [System.Text.Encoding]::UTF8.GetBytes($item) ) | 
-                        ForEach { "{0:x2}" -f $_ })
+                        ForEach-Object { "{0:x2}" -f $_ })
                     
                     #If multiple algorithms are used, then they will be added to existing object                
                     $object = Add-Member -InputObject $Object -MemberType NoteProperty -Name $Type -Value $Hash -PassThru

--- a/PSDepend/Private/Get-Parameter.ps1
+++ b/PSDepend/Private/Get-Parameter.ps1
@@ -82,7 +82,7 @@ Function Get-Parameter {
 
          foreach ($p in $MoreParameters | Where-Object { !$Parameters.ContainsKey($_.Name) } ) {
             Write-Debug ("INITIALLY: " + $p.Name)
-            $Parameters.($p.Name) = $p | Select *
+            $Parameters.($p.Name) = $p | Select-Object *
          }
 
          [Array]$Dynamic = $MoreParameters | Where-Object { $_.IsDynamic }
@@ -93,7 +93,7 @@ Function Get-Parameter {
                   $Parameters.($d.Name).DynamicProvider += $provider.Name
                } else {
                   Write-Debug ("CREATE:" + $d.Name + " " + $provider.Name)
-                  $Parameters.($d.Name) = $Parameters.($d.Name) | Select *, @{ n="DynamicProvider";e={ @($provider.Name) } }
+                  $Parameters.($d.Name) = $Parameters.($d.Name) | Select-Object *, @{ n="DynamicProvider";e={ @($provider.Name) } }
                }
             } 
          }
@@ -124,7 +124,7 @@ Function Get-Parameter {
             if(!$SkipProviderParameters -and $Command.Source -eq "Microsoft.PowerShell.Management") {
                ## The best I can do is to validate that the command has a parameter which could accept a string path
                foreach($param in $Command.Parameters.Values) {
-                  if(([String[]],[String] -contains $param.ParameterType) -and ($param.ParameterSets.Values | Where { $_.Position -ge 0 })) {
+                  if(([String[]],[String] -contains $param.ParameterType) -and ($param.ParameterSets.Values | Where-Object { $_.Position -ge 0 })) {
                      $NoProviderParameters = $false
                      break
                   }
@@ -165,7 +165,7 @@ Function Get-Parameter {
             $ParameterNames = $Parameters.Keys + $Aliases
             foreach ($p in $($Parameters.Keys)) {
                $short = "^"
-               $aliases = @($p) + @($Parameters.$p.Aliases) | sort-object { $_.Length }
+               $aliases = @($p) + @($Parameters.$p.Aliases) | Sort-Object { $_.Length }
                $shortest = "^" + @($aliases)[0]
 
                foreach($name in $aliases) {
@@ -187,7 +187,7 @@ Function Get-Parameter {
                }
 
                # ValidateSet...
-               $Parameters.$p = $Parameters.$p | Add-Member NoteProperty ValidateSetValues ($Parameters.$p.Attributes | Where{$_.TypeId.name -like 'ValidateSetAttribute'}).ValidValues -Force -Passthru
+               $Parameters.$p = $Parameters.$p | Add-Member NoteProperty ValidateSetValues ($Parameters.$p.Attributes | Where-Object {$_.TypeId.name -like 'ValidateSetAttribute'}).ValidValues -Force -Passthru
 
             }
 

--- a/PSDepend/Private/Get-ParameterName.ps1
+++ b/PSDepend/Private/Get-ParameterName.ps1
@@ -19,11 +19,11 @@ Function Get-ParameterName {
     )
     if($parameterset)
     {
-        ((Get-Command -name $command).ParameterSets | ?{$_.name -eq $parameterset} ).Parameters.Name | ?{($exclude + $excludeDefault) -notcontains $_}
+        ((Get-Command -name $command).ParameterSets | Where-Object {$_.name -eq $parameterset} ).Parameters.Name | Where-Object {($exclude + $excludeDefault) -notcontains $_}
     }
 
     else
     {
-        ((Get-Command -name $command).ParameterSets | ?{$_.name -eq "__AllParameterSets"} ).Parameters.Name | ?{($exclude + $excludeDefault) -notcontains $_}
+        ((Get-Command -name $command).ParameterSets | Where-Object {$_.name -eq "__AllParameterSets"} ).Parameters.Name | Where-Object {($exclude + $excludeDefault) -notcontains $_}
     }
 }

--- a/PSDepend/Private/Get-ProjectDetail.ps1
+++ b/PSDepend/Private/Get-ProjectDetail.ps1
@@ -67,7 +67,7 @@ function Get-ProjectDetail {
             Where-Object {
                 Test-Path $(Join-Path $_.FullName "$($_.name).psd1")
             } |
-            Select -ExpandProperty Fullname
+            Select-Object -ExpandProperty Fullname
 
         if( @($ProjectPaths).Count -gt 1 )
         {

--- a/PSDepend/Private/Get-PropertyOrder.ps1
+++ b/PSDepend/Private/Get-PropertyOrder.ps1
@@ -48,7 +48,7 @@ Function Get-PropertyOrder {
         #Get properties that meet specified parameters
         $firstObject.psobject.properties |
             Where-Object { $memberType -contains $_.memberType } |
-            Select -ExpandProperty Name |
+            Select-Object -ExpandProperty Name |
             Where-Object{ -not $excludeProperty -or $excludeProperty -notcontains $_ }
     }
 } #Get-PropertyOrder

--- a/PSDepend/Private/Resolve-DependScripts.ps1
+++ b/PSDepend/Private/Resolve-DependScripts.ps1
@@ -9,7 +9,7 @@ function Resolve-DependScripts
             $unresolvedPath = [string] $object
             if ($unresolvedPath -notmatch '[\*\?\[\]]' -and
                 (Test-Path -LiteralPath $unresolvedPath -PathType Leaf) -and
-                (Get-Item -LiteralPath $unresolvedPath) -is [System.IO.FileInfo])
+                (Get-Item -LiteralPath $unresolvedPath -Force) -is [System.IO.FileInfo])
             {
                 $extension = [System.IO.Path]::GetExtension($unresolvedPath)
                 if ($extension -ne '.psd1')

--- a/PSDepend/Private/Sort-WithCustomList.ps1
+++ b/PSDepend/Private/Sort-WithCustomList.ps1
@@ -13,13 +13,12 @@ Function Sort-ObjectWithCustomList {
         [Object[]]
         $CustomList
     )
-
     Begin
     {
         # convert customList (array) to hash
         $hash = @{}
         $rank = 0
-        $customList | Select -Unique | ForEach-Object {
+        $customList | Select-Object -Unique | ForEach-Object {
             $key = $_
             $hash.Add($key, $rank)
             $rank++

--- a/PSDepend/Private/Test-PlatformSupport.ps1
+++ b/PSDepend/Private/Test-PlatformSupport.ps1
@@ -1,0 +1,41 @@
+﻿function Test-PlatformSupport {
+    [cmdletbinding()]
+    param(
+        [string[]]$Support
+    )
+
+    # test core/full
+    if('Core' -eq $PSVersionTable.PSEdition) {
+        if($Support -notcontains 'core') {
+            Write-Verbose "Supported platforms [$Support] does not contain [core].  Pull requests welcome!"
+            return $false
+        }
+    }
+    else { # full windows powershell
+        if($Support -notcontains 'windows') {
+            Write-Verbose "Supported platforms [$Support] does not contain [windows].  Pull requests welcome!"
+            return $false
+        }
+    }
+
+    if($IsLinux) {
+        if($Support -notcontains 'linux') {
+            Write-Verbose "Supported platforms [$Support] does not contain [linux].  Pull requests welcome!"
+            return $false
+        }
+    }
+    if($IsMacOS) {
+        if($Support -notcontains 'macos') {
+            Write-Verbose "Supported platforms [$Support] does not contain [macos].  Pull requests welcome!"
+            return $false
+        }
+    }
+    if($IsWindows) {
+        # covers support for core powershell on windows
+        if($Support -notcontains 'windows') {
+            Write-Verbose "Supported platforms [$Support] does not contain [windows].  Pull requests welcome!"
+            return $false
+        }
+    }
+    $true
+}

--- a/PSDepend/Private/Test-PlatformSupport.ps1
+++ b/PSDepend/Private/Test-PlatformSupport.ps1
@@ -1,39 +1,40 @@
 ﻿function Test-PlatformSupport {
     [cmdletbinding()]
     param(
+        $Type,
         [string[]]$Support
     )
 
     # test core/full
     if('Core' -eq $PSVersionTable.PSEdition) {
         if($Support -notcontains 'core') {
-            Write-Verbose "Supported platforms [$Support] does not contain [core].  Pull requests welcome!"
+            Write-Verbose "Supported platforms [$Support] for type [$Type] does not contain [core].  Pull requests welcome!"
             return $false
         }
     }
     else { # full windows powershell
         if($Support -notcontains 'windows') {
-            Write-Verbose "Supported platforms [$Support] does not contain [windows].  Pull requests welcome!"
+            Write-Verbose "Supported platforms [$Support] for type [$Type] does not contain [windows].  Pull requests welcome!"
             return $false
         }
     }
 
     if($IsLinux) {
         if($Support -notcontains 'linux') {
-            Write-Verbose "Supported platforms [$Support] does not contain [linux].  Pull requests welcome!"
+            Write-Verbose "Supported platforms [$Support] for type [$Type] does not contain [linux].  Pull requests welcome!"
             return $false
         }
     }
     if($IsMacOS) {
         if($Support -notcontains 'macos') {
-            Write-Verbose "Supported platforms [$Support] does not contain [macos].  Pull requests welcome!"
+            Write-Verbose "Supported platforms [$Support] for type [$Type] does not contain [macos].  Pull requests welcome!"
             return $false
         }
     }
     if($IsWindows) {
         # covers support for core powershell on windows
         if($Support -notcontains 'windows') {
-            Write-Verbose "Supported platforms [$Support] does not contain [windows].  Pull requests welcome!"
+            Write-Verbose "Supported platforms [$Support] for type [$Type] does not contain [windows].  Pull requests welcome!"
             return $false
         }
     }

--- a/PSDepend/Public/Get-PSDependType.ps1
+++ b/PSDepend/Public/Get-PSDependType.ps1
@@ -110,7 +110,7 @@ Function Get-PSDependType {
             [pscustomobject]@{
                 DependencyType = $Type
                 Supports = $Support
-                Supported = Test-PlatformSupport $Support
+                Supported = Test-PlatformSupport -Type $Type -Support $Support
                 Description = $DependencyDefinitions.$Type.Description
                 DependencyScript = $ScriptPath
                 HelpContent = $ScriptHelp

--- a/PSDepend/Public/Get-PSDependType.ps1
+++ b/PSDepend/Public/Get-PSDependType.ps1
@@ -106,8 +106,11 @@ Function Get-PSDependType {
         }
         else
         {
+            $Support = @($DependencyDefinitions.$Type.Supports)
             [pscustomobject]@{
                 DependencyType = $Type
+                Supports = $Support
+                Supported = Test-PlatformSupport $Support
                 Description = $DependencyDefinitions.$Type.Description
                 DependencyScript = $ScriptPath
                 HelpContent = $ScriptHelp
@@ -115,6 +118,3 @@ Function Get-PSDependType {
         }
     }
 }
-
-
-

--- a/PSDepend/Public/Invoke-DependencyScript.ps1
+++ b/PSDepend/Public/Invoke-DependencyScript.ps1
@@ -87,7 +87,7 @@ Function Invoke-DependencyScript {
             $PSDependType = ($PSDependTypes | Where-Object {$_.DependencyType -eq $DependencyType})
             if(-not $PSDependType.Supported)
             {
-                Write-Error "Skipping dependency type [$DependencyType]`nThis dependency does not support your platform`nSupported platforms: [$($PSDependType.Supports)]"
+                Write-Warning "Skipping dependency type [$DependencyType]`nThis dependency does not support your platform`nSupported platforms: [$($PSDependType.Supports)]"
                 continue
             }
             $DependencyScript = $DependencyDefs.$DependencyType

--- a/PSDepend/Public/Invoke-DependencyScript.ps1
+++ b/PSDepend/Public/Invoke-DependencyScript.ps1
@@ -75,7 +75,7 @@ Function Invoke-DependencyScript {
     }
     Process
     {
-        Write-Verbose "Dependencies:`n$($Dependency | Select -Property * | Out-String)"
+        Write-Verbose "Dependencies:`n$($Dependency | Select-Object -Property * | Out-String)"
 
         #Get definitions, and dependencies in this particular psd1
         $DependencyDefs = Get-PSDependScript

--- a/PSDepend/Public/Invoke-DependencyScript.ps1
+++ b/PSDepend/Public/Invoke-DependencyScript.ps1
@@ -71,6 +71,7 @@ Function Invoke-DependencyScript {
     {
         # This script reads a depend.psd1, installs dependencies as defined
         Write-Verbose "Running Invoke-DependencyScript with ParameterSetName '$($PSCmdlet.ParameterSetName)' and params: $($PSBoundParameters | Out-String)"
+        $PSDependTypes = Get-PSDependType
     }
     Process
     {
@@ -83,6 +84,12 @@ Function Invoke-DependencyScript {
         #Build up hash, we call each dependencytype script for applicable dependencies
         foreach($DependencyType in $TheseDependencyTypes)
         {
+            $PSDependType = ($PSDependTypes | Where-Object {$_.DependencyType -eq $DependencyType})
+            if(-not $PSDependType.Supported)
+            {
+                Write-Error "Skipping dependency type [$DependencyType]`nThis dependency does not support your platform`nSupported platforms: [$($PSDependType.Supports)]"
+                continue
+            }
             $DependencyScript = $DependencyDefs.$DependencyType
             if(-not $DependencyScript)
             {

--- a/PSDepend/en-US/about_PSDepend_Definitions.help.txt
+++ b/PSDepend/en-US/about_PSDepend_Definitions.help.txt
@@ -139,18 +139,13 @@ DETAILED DESCRIPTION
       - You want to extend PSDepend to add more DependencyTypes
       - You want to move the PSDependMap.psd1 to a central location that multiple systems could point to
 
-    There are three attributes to each DependencyType in this file:
+    There are four attributes to each DependencyType in this file:
 
         DependencyType Name:  The name of this DependencyType
         Script:               The name of the script to process these DependencyTypes
                               This looks in the PSDepend module path, under PSDependScripts
                               You can theoretically specify an absolute path
         Description:          Description for this DependencyType. Provided to a user when they run Get-PSDependType.
-
-    The PSDependMap.psd1 file will have one or more DependencyType blocks like this:
-
-        PSGalleryModule:
-          Script: PSGalleryModule.ps1
-          Description: Install a PowerShell module from the PowerShell Gallery.
+        Supports:             Platforms this script supports:  windows, core, macos, linux
 
     See about_PSDepend for more information


### PR DESCRIPTION
Starting to work on xplat support (#11).  One thing we'll need is a way to narrow down which dependency scripts support which platforms.  This is an initial, minimal-thought take on adding this to the PSDependMap schema and using that data in a few spots...

* Add supports <array of platforms> to PSDependMap
* Add supports, and supported properties to Get-PSDependType output
* Skip invocation of dependency scripts that do not support the current platform

Currently we do not fail all dependencies, we simply skip unsupported dependencies - open to failing all the things instead

Hit me up if you have any ideas or concerns!  Will leave this open a few days.
