### PR TITLE
Fix local build environment

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -3,11 +3,11 @@
 # Grab nuget bits, install modules, set build variables, start build.
 Get-PackageProvider -Name NuGet -ForceBootstrap | Out-Null
 
-Install-Module Psake, PSDeploy, BuildHelpers -force -AllowClobber
-Install-Module Pester -MinimumVersion 4.1 -Force -AllowClobber -SkipPublisherCheck
+Install-Module Psake, PSDeploy, BuildHelpers -force -AllowClobber -Scope CurrentUser
+Install-Module Pester -MinimumVersion 4.1 -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser
 Import-Module Psake, BuildHelpers
 
-Set-BuildEnvironment
+Set-BuildEnvironment -ErrorAction SilentlyContinue
 
 Invoke-psake -buildFile $ENV:BHProjectPath\psake.ps1 -taskList $Task -nologo
 exit ( [int]( -not $psake.build_success ) )

--- a/psake.ps1
+++ b/psake.ps1
@@ -2,7 +2,7 @@
 # Init some things
 Properties {
     # Find the build folder based on build system
-        $ProjectRoot = $ENV:BHProjectPath
+        $ProjectRoot = Convert-Path $ENV:BHProjectPath
         if(-not $ProjectRoot)
         {
             $ProjectRoot = $PSScriptRoot


### PR DESCRIPTION
* allows build to run locally without throwing errors if user is not admin
* use `Convert-Path` to remove any PSDrive from Pester output file (eg: `Project:\PSDepend`)