### PR TITLE
Featue: Support Powershell Core

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "powershell.codeFormatting.openBraceOnSameLine": false,
+    "powershell.codeFormatting.ignoreOneLineBlock": false,
+    "powershell.codeFormatting.whitespaceAfterSeparator": false,
+    "powershell.codeFormatting.whitespaceAroundOperator": false,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": false
+}

--- a/Examples/Install-PSDepend.ps1
+++ b/Examples/Install-PSDepend.ps1
@@ -16,7 +16,7 @@ if(-not ($NugetPath = (Get-Command 'nuget.exe' -ErrorAction SilentlyContinue).Pa
 }
 
 # Bootstrap PSDepend, re-use nuget.exe for the module
-if($path) { $null = mkdir $path -Force }
+if($path) { $null = New-Item $path -ItemType Directory -Force }
 $NugetParams = 'install', 'PSDepend', '-Source', 'https://www.powershellgallery.com/api/v2/',
                '-ExcludeVersion', '-NonInteractive', '-OutputDirectory', $Path
 & $NugetPath @NugetParams

--- a/Examples/ModuleDependencies.md
+++ b/Examples/ModuleDependencies.md
@@ -58,7 +58,7 @@ Set-Content C:\MyModule\Requirements.psd1 -Value @'
         DependencyType = 'Command'
         Source = '$DepFolder = "$DependencyFolder\Dependencies"',
                  'if(-not (Test-Path $DepFolder\AzCopy\AzCopy.exe)){
-                      $null = mkdir $DepFolder\AzCopy -Force;
+                      $null = New-Item $DepFolder\AzCopy -ItemType Directory -Force;
                       Start-Process msiexec -ArgumentList "/a $DepFolder\azcopy.msi /qb TARGETDIR=$DepFolder\AzTemp /quiet" -Wait;
                       Copy-Item "$DepFolder\AzTemp\Microsoft SDKs\Azure\AzCopy\*" $DepFolder\AzCopy -Force;
                       Remove-Item $DepFolder\AZTemp -Recurse -Force;

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -102,7 +102,7 @@ $GottaInstall = $True
 if(-not (Test-Path $Target) -and $PSDependAction -contains 'Install')
 {
     Write-Verbose "Creating folder [$Target] for git dependency [$Name]"
-    $null = mkdir $Target -Force
+    $null = New-Item $Target -ItemType Directory -Force
 }
 
 if(-not (Test-Path $RepoPath))

--- a/PSDepend/Private/Add-ToItemCollection.ps1
+++ b/PSDepend/Private/Add-ToItemCollection.ps1
@@ -1,6 +1,6 @@
 ﻿function Add-ToItemCollection {
     param(
-        $Delimiter = ';',
+        $Delimiter = [IO.Path]::PathSeparator,
         $Reference, # e.g. ENV:Path
         $Item, # e.g. 'C:\Project',
         [switch]$Append

--- a/PSDepend/Private/Bootstrap-Nuget.ps1
+++ b/PSDepend/Private/Bootstrap-Nuget.ps1
@@ -18,7 +18,7 @@ function BootStrap-Nuget {
         if(-not (Test-Path $Parent))
         {
             Write-Verbose "Creating parent paths to [$NugetPath]'s parent: [$Parent]"
-            mkdir $Parent -Force   
+            $null = New-Item $Parent -ItemType Directory -Force
         }
         Write-Verbose "Downloading nuget to [$NugetPath]"
         Invoke-WebRequest -uri 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile $NugetPath

--- a/Tests/DependFiles/filedownload.depend.psd1
+++ b/Tests/DependFiles/filedownload.depend.psd1
@@ -2,6 +2,6 @@
     'sqlite_dll' = @{
         DependencyType = 'FileDownload'
         Source = 'https://github.com/RamblingCookieMonster/PSSQLite/blob/master/PSSQLite/x64/System.Data.SQLite.dll?raw=true'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
     }
 }

--- a/Tests/DependFiles/filesystem.depend.psd1
+++ b/Tests/DependFiles/filesystem.depend.psd1
@@ -2,6 +2,6 @@
     'notepad' = @{
         DependencyType = 'FileSystem'
         Source = 'C:\windows\notepad.exe'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
     }
 }

--- a/Tests/DependFiles/git.depend.psd1
+++ b/Tests/DependFiles/git.depend.psd1
@@ -2,7 +2,7 @@
     'buildhelpers' = @{
         Name = 'https://github.com/RamblingCookieMonster/BuildHelpers.git'
         Version = 'd32a9495c39046c851ceccfb7b1a85b17d5be051'
-        Target = 'C:\PSDependPesterTest\buildhelpers'
+        Target = 'TestDrive:/PSDependPesterTest\buildhelpers'
     }
     'https://github.com/ramblingcookiemonster/PSDeploy' = 'master'
     'https://github.com/nightroman/Invoke-Build' = 'ac54571010d8ca5107fc8fa1a69278102c9aa077'

--- a/Tests/DependFiles/psgallerymodule.addtopath.depend.psd1
+++ b/Tests/DependFiles/psgallerymodule.addtopath.depend.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     'imaginary' = @{
         Version = '1.2.5'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         AddToPath = $True
     }
 }

--- a/Tests/DependFiles/psgallerymodule.latestaddtopath.depend.psd1
+++ b/Tests/DependFiles/psgallerymodule.latestaddtopath.depend.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     'imaginary' = @{
         Version = 'latest'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         AddToPath = $True
     }
 }

--- a/Tests/DependFiles/psgallerynuget.addtopath.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.addtopath.depend.psd1
@@ -2,7 +2,7 @@
     'imaginary' = @{
         DependencyType = 'PSGalleryNuget'
         Version = '1.2.5'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         AddToPath = $True
         Parameters = @{
             Force = $true

--- a/Tests/DependFiles/psgallerynuget.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.depend.psd1
@@ -2,7 +2,7 @@
     'jenkins' = @{
         DependencyType = 'PSGalleryNuget'
         Version = 'latest'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         Parameters = @{
             Force = $true
         }

--- a/Tests/DependFiles/psgallerynuget.latestaddtopath.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.latestaddtopath.depend.psd1
@@ -2,7 +2,7 @@
     'imaginary' = @{
         DependencyType = 'PSGalleryNuget'
         Version = 'latest'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         AddToPath = $True
         Parameters = @{
             Force = $true

--- a/Tests/DependFiles/psgallerynuget.latestversion.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.latestversion.depend.psd1
@@ -2,7 +2,7 @@
     'jenkins' = @{
         DependencyType = 'PSGalleryNuget'
         Version = 'latest'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         Parameters = @{
             Force = $true
         }

--- a/Tests/DependFiles/psgallerynuget.sameversion.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.sameversion.depend.psd1
@@ -2,7 +2,7 @@
     'jenkins' = @{
         DependencyType = 'PSGalleryNuget'
         Version = '1.2.5'
-        Target = 'C:\PSDependPesterTest'
+        Target = 'TestDrive:/PSDependPesterTest'
         Parameters = @{
             Force = $true
         }

--- a/Tests/DependFiles/savemodule.depend.psd1
+++ b/Tests/DependFiles/savemodule.depend.psd1
@@ -1,5 +1,5 @@
 ﻿@{
     'jenkins' = @{
-        target = 'C:\PSDependPesterTest'
+        target = 'TestDrive:/PSDependPesterTest'
     }
 }

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -730,8 +730,12 @@ InModuleScope 'PSDepend' {
 
         Context 'Test-Dependency' {
             
+            if (-not (Get-Command Get-Package -Module PackageManagement)) {
             function Get-Package {[cmdletbinding()]param( $ProviderName, $Name, $RequiredVersion) write-verbose "WTF NOW"}
+            }
+            if (-not (Get-Command Install-Package -Module PackageManagement)) {
             function Install-Package {[cmdletbinding()]param( $Source, $Name, $RequiredVersion, $Force)}
+            }
             function Get-PackageSource { @([pscustomobject]@{Name = 'chocolatey'; ProviderName = 'chocolatey'}) }
 
             BeforeEach {
@@ -881,9 +885,5 @@ InModuleScope 'PSDepend' {
                 Invoke-PSDepend @Verbose -Path "$TestDepends\npm.depend.psd1" -Test -Quiet | Should Be $true
             }
         }
-    }
-
-    It "fails until PR is complete" {
-        $false | Should Be $true
     }
 }

--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -1,23 +1,20 @@
 if(-not $ENV:BHProjectPath)
 {
-    Set-BuildEnvironment -Path $PSScriptRoot\..
+    Set-BuildEnvironment -Path "$PSScriptRoot/.."
 }
 Remove-Module $ENV:BHProjectName -ErrorAction SilentlyContinue
 Import-Module (Join-Path $ENV:BHProjectPath $ENV:BHProjectName) -Force
-
-$null = mkdir 'C:\PSDependPesterTest' -force
 
 # Maybe use a convention for describe/context/it... these are all over the place...
 # Pull requests welcome!
 
 InModuleScope 'PSDepend' {
 
-    $TestDepends = Join-Path $ENV:BHProjectPath Tests\DependFiles
+    $TestDepends = Join-Path $ENV:BHProjectPath "Tests/DependFiles"
     $PSVersion = $PSVersionTable.PSVersion.Major
     $ProjectRoot = $ENV:BHProjectPath
-    $SavePath = 'C:\PSDependPesterTest'
     $ExistingPSModulePath = $env:PSModulePath.PSObject.Copy()
-    $ExistingPath = $env:Path.PSObject.Copy()
+    $ExistingPath = $env:PATH.PSObject.Copy()
 
     $Verbose = @{}
     if($ENV:BHBranchName -notlike "master" -or $env:BHCommitMessage -match "!verbose")
@@ -27,10 +24,12 @@ InModuleScope 'PSDepend' {
 
     Describe "PSGalleryModule Type PS$PSVersion" {
 
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
+
         Context 'Installs Modules' {
             Mock Install-Module { Return $true }
             
-            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.depend.psd1" -Force
+            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends/psgallerymodule.depend.psd1" -Force
 
             It 'Should execute Install-Module' {
                 Assert-MockCalled Install-Module -Times 1 -Exactly
@@ -44,7 +43,7 @@ InModuleScope 'PSDepend' {
         Context 'Saves Modules' {
             Mock Save-Module { Return $true }
             
-            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\savemodule.depend.psd1" -Force
+            $Results = Invoke-PSDepend @Verbose -Path "$TestDepends/savemodule.depend.psd1" -Force
 
             It 'Should execute Save-Module' {
                 Assert-MockCalled Save-Module -Times 1 -Exactly
@@ -59,7 +58,7 @@ InModuleScope 'PSDepend' {
             Mock Install-Module { throw "Unable to find repository 'Blah'" } -ParameterFilter { $Repository -eq 'Blah'}
 
             It 'Throws because Repository could not be found' {
-                $Results = { Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.missingrepo.depend.psd1" -Force -ErrorAction Stop }
+                $Results = { Invoke-PSDepend @Verbose -Path "$TestDepends/psgallerymodule.missingrepo.depend.psd1" -Force -ErrorAction Stop }
                 $Results | Should Throw
             }
         }
@@ -74,7 +73,7 @@ InModuleScope 'PSDepend' {
             Mock Find-Module
 
             It 'Skips Install-Module' {
-                Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.sameversion.depend.psd1" -Force -ErrorAction Stop
+                Invoke-PSDepend @Verbose -Path "$TestDepends/psgallerymodule.sameversion.depend.psd1" -Force -ErrorAction Stop
 
                 Assert-MockCalled Get-Module -Times 1 -Exactly
                 Assert-MockCalled Find-Module -Times 0 -Exactly
@@ -96,7 +95,7 @@ InModuleScope 'PSDepend' {
             }
 
             It 'Skips Install-Module' {
-                Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.latestversion.depend.psd1" -Force -ErrorAction Stop
+                Invoke-PSDepend @Verbose -Path "$TestDepends/psgallerymodule.latestversion.depend.psd1" -Force -ErrorAction Stop
 
                 Assert-MockCalled Get-Module -Times 1 -Exactly
                 Assert-MockCalled Find-Module -Times 1 -Exactly
@@ -117,7 +116,7 @@ InModuleScope 'PSDepend' {
                         Version = '1.2.5'
                     }
                 }
-                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.sameversion.depend.psd1" |
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends/psgallerymodule.sameversion.depend.psd1" |
                         Test-Dependency -Quiet )
                 $Results.Count | Should be 1
                 $Results[0] | Should be $True
@@ -134,7 +133,7 @@ InModuleScope 'PSDepend' {
                         Version = '1.2.5'
                     }
                 }
-                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.latestversion.depend.psd1" |
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends/psgallerymodule.latestversion.depend.psd1" |
                         Test-Dependency -Quiet )
                 $Results.Count | Should be 1
                 $Results[0] | Should be $True
@@ -142,7 +141,7 @@ InModuleScope 'PSDepend' {
 
             It "Returns `$false when it doesn't find an existing module" {
                 Mock Get-Module { $null }
-                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.sameversion.depend.psd1" |
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends/psgallerymodule.sameversion.depend.psd1" |
                         Test-Dependency -Quiet )
                 $Results.Count | Should be 1
                 $Results[0] | Should be $False
@@ -153,7 +152,7 @@ InModuleScope 'PSDepend' {
                         Version = '1.2.4'
                     }
                 }
-                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.sameversion.depend.psd1" |
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends/psgallerymodule.sameversion.depend.psd1" |
                         Test-Dependency -Quiet )
                 $Results.Count | Should be 1
                 $Results[0] | Should be $False
@@ -170,7 +169,7 @@ InModuleScope 'PSDepend' {
                         Version = '1.2.5'
                     }
                 }
-                $Results = @( Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.latestversion.depend.psd1" |
+                $Results = @( Get-Dependency @Verbose -Path "$TestDepends/psgallerymodule.latestversion.depend.psd1" |
                         Test-Dependency -Quiet )
                 $Results.Count | Should be 1
                 $Results[0] | Should be $False
@@ -181,7 +180,7 @@ InModuleScope 'PSDepend' {
             It 'Runs Import-Module when import is specified' {
                 Mock Install-Module {}
                 Mock Import-Module
-                $Results = Get-Dependency @Verbose -Path "$TestDepends\psgallerymodule.depend.psd1" | Import-Dependency @Verbose
+                $Results = Get-Dependency @Verbose -Path "$TestDepends/psgallerymodule.depend.psd1" | Import-Dependency @Verbose
                 Assert-MockCalled -CommandName Import-Module -Times 1 -Exactly
                 Assert-MockCalled -CommandName Install-Module -Times 0 -Exactly
             }            
@@ -191,7 +190,7 @@ InModuleScope 'PSDepend' {
             It 'Adds folder to path' {
                 Mock Save-Module {$True}
                 Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerymodule.addtopath.depend.psd1" -Force -ErrorAction Stop
-                $env:PSModulePath -split ";" -contains $SavePath | Should Be $True
+                ($env:PSModulePath -split ([IO.Path]::PathSeparator)) -contains $SavePath | Should Be $True
                 $ENV:PSModulePath = $ExistingPSModulePath
             }
         }
@@ -237,7 +236,7 @@ InModuleScope 'PSDepend' {
                 Assert-MockCalled Import-Module -Times 1 -Exactly -Scope It
 
                 # then
-                $env:PSModulePath -split ";" -contains $SavePath | Should Be $True
+                ($env:PSModulePath -split ([IO.Path]::PathSeparator)) -contains $SavePath | Should Be $True
             }
         }
 
@@ -253,7 +252,10 @@ InModuleScope 'PSDepend' {
         }
     }
 
-    Describe "Git Type PS$PSVersion" {
+    Describe "Git Type PS$PSVersion"  -Tag "WindowsOnly" {
+
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
+
         Context 'Installs Module' {
             Mock Invoke-ExternalCommand {
                 [pscustomobject]@{
@@ -261,10 +263,10 @@ InModuleScope 'PSDepend' {
                     Arg = $Args
                 }
             } -ParameterFilter {$Arguments -contains 'checkout' -or $Arguments -contains 'clone'}
-            Mock mkdir { return $true }
-            Mock Push-Location
-            Mock Pop-Location
-            Mock Set-Location
+            Mock New-Item { return $true }
+            Mock Push-Location {}
+            Mock Pop-Location {}
+            Mock Set-Location {}
             Mock Test-Path { return $False } -ParameterFilter {$Path -match "Invoke-Build$|PSDeploy$"}
 
             $Dependencies = Get-Dependency @Verbose -Path "$TestDepends\git.depend.psd1"
@@ -284,10 +286,10 @@ InModuleScope 'PSDepend' {
 
         }
         Context 'Tests dependency' {
-            Mock mkdir { return $true }
-            Mock Push-Location
-            Mock Pop-Location
-            Mock Set-Location
+            Mock New-Item { return $true }
+            Mock Push-Location {}
+            Mock Pop-Location {}
+            Mock Set-Location {}
             Mock Invoke-ExternalCommand -ParameterFilter {$Arguments -contains 'checkout' -or $Arguments -contains 'clone'}
             
 
@@ -308,7 +310,9 @@ InModuleScope 'PSDepend' {
         }
     }
 
-    Describe "FileDownload Type PS$PSVersion" {
+    Describe "FileDownload Type PS$PSVersion" -Tag "WindowsOnly" {
+
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
 
         Context 'Installs dependency' {
             Mock Get-WebFile {
@@ -340,7 +344,7 @@ InModuleScope 'PSDepend' {
         }
 
         Remove-Item $SavePath -Force -Recurse
-        mkdir $SavePath -Force
+        $null = New-Item $SavePath -ItemType Directory -Force
 
         Context 'Tests dependency' {
             It 'Returns $false if file does not exist' {
@@ -362,7 +366,9 @@ InModuleScope 'PSDepend' {
         }
     }
     
-    Describe "PSGalleryNuget Type PS$PSVersion" {
+    Describe "PSGalleryNuget Type PS$PSVersion" -Tag "WindowsOnly" {
+
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
 
         Context 'Installs Modules' {
             Mock Test-Path { Return $true } -ParameterFilter { $PathType -eq 'Container' }
@@ -514,7 +520,7 @@ InModuleScope 'PSDepend' {
                 Mock Invoke-ExternalCommand {$True}
                 Mock Import-Module 
                 $Results = Invoke-PSDepend @Verbose -Path "$TestDepends\psgallerynuget.addtopath.depend.psd1" -Force -ErrorAction Stop
-                $env:PSModulePath -split ";" -contains $SavePath | Should Be $True
+                $env:PSModulePath -split ([IO.Path]::PathSeparator) -contains $SavePath | Should Be $True
                 $ENV:PSModulePath = $ExistingPSModulePath
             }
         }
@@ -562,12 +568,14 @@ InModuleScope 'PSDepend' {
                 Assert-MockCalled Import-Module  -Times 1 -Exactly -Scope It
 
                 # then
-                $env:PSModulePath -split ";" -contains $SavePath | Should Be $True
+                (($env:PSModulePath -split ([IO.Path]::PathSeparator))) -contains $SavePath | Should Be $True
             }
         }
     }
 
-    Describe "FileSystem Type PS$PSVersion" {
+    Describe "FileSystem Type PS$PSVersion" -Tag "WindowsOnly" {
+
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
 
         Context 'Installs dependency' {
             Mock Copy-Item
@@ -594,7 +602,7 @@ InModuleScope 'PSDepend' {
         }
 
         Remove-Item $SavePath -Force -Recurse
-        mkdir $SavePath -Force
+        $null = New-Item $SavePath -ItemType Directory -Force
 
         Context 'Tests dependency' {
             It 'Returns $false if file does not exist' {
@@ -618,6 +626,9 @@ InModuleScope 'PSDepend' {
     }
 
     Describe "Package Type PS$PSVersion" -tag pkg {
+
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
+
         # So... these didn't work with mocking.  Create function, define alias to override any function call, mock that.
         function Get-Package {[cmdletbinding()]param( $ProviderName, $Name, $RequiredVersion)}
         function Install-Package {[cmdletbinding()]param( $Source, $Name, $RequiredVersion)}
@@ -798,6 +809,8 @@ InModuleScope 'PSDepend' {
 
     Describe "Command Type PS$PSVersion" {
 
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
+
         Context 'Invokes a command' {
 
             $Dependencies = @(Get-Dependency @Verbose -Path "$TestDepends\command.depend.psd1")
@@ -816,10 +829,12 @@ InModuleScope 'PSDepend' {
 
     Describe "Npm Type PS$PSVersion" {
 
+        $SavePath = (New-Item 'TestDrive:/PSDependPesterTest' -ItemType Directory -Force).FullName
+
         Context 'Installs Dependency' {
             Mock Get-NodeModule {return $null}
             Mock Install-NodeModule {}
-            Mock mkdir {return true}
+            Mock New-Item {return true}
             Mock Push-Location
             Mock Pop-Location
 
@@ -841,7 +856,7 @@ InModuleScope 'PSDepend' {
 
         Context 'Tests Dependency' {
             Mock Install-NodeModule {}
-            Mock mkdir {return true}
+            Mock New-Item {return true}
             Mock Push-Location
             Mock Pop-Location
 
@@ -867,6 +882,8 @@ InModuleScope 'PSDepend' {
             }
         }
     }
-}
 
-Remove-Item C:\PSDependPesterTest -Force -Recurse
+    It "fails until PR is complete" {
+        $false | Should Be $true
+    }
+}

--- a/build.ps1
+++ b/build.ps1
@@ -3,11 +3,11 @@
 # Grab nuget bits, install modules, set build variables, start build.
 Get-PackageProvider -Name NuGet -ForceBootstrap | Out-Null
 
-Install-Module Psake, PSDeploy, BuildHelpers -force -AllowClobber
-Install-Module Pester -MinimumVersion 4.1 -Force -AllowClobber -SkipPublisherCheck
+Install-Module Psake, PSDeploy, BuildHelpers -force -AllowClobber -Scope CurrentUser
+Install-Module Pester -MinimumVersion 4.1 -Force -AllowClobber -SkipPublisherCheck -Scope CurrentUser
 Import-Module Psake, BuildHelpers
 
-Set-BuildEnvironment
+Set-BuildEnvironment -ErrorAction SilentlyContinue
 
 Invoke-psake -buildFile $ENV:BHProjectPath\psake.ps1 -taskList $Task -nologo
 exit ( [int]( -not $psake.build_success ) )

--- a/psake.ps1
+++ b/psake.ps1
@@ -7,6 +7,7 @@ Properties {
         {
             $ProjectRoot = $PSScriptRoot
         }
+        $ProjectRoot  = Convert-Path $ProjectRoot
 
     try {
         $script:IsWindows = (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) -or $IsWindows
@@ -44,11 +45,10 @@ Task Test -Depends Init  {
 
     # Gather test results. Store them in a variable and file
     $pesterParameters = @{
-        # tag = "Debug" 
         Path         = "$ProjectRoot\Tests"
         PassThru     = $true
         OutputFormat = "NUnitXml" 
-        OutputFile   = "$(Convert-Path $ProjectRoot)\$TestFile"
+        OutputFile   = "$ProjectRoot\$TestFile"
     }
     if (-Not $IsWindows) { $pesterParameters["ExcludeTag"] = "WindowsOnly" }
     $TestResults = Invoke-Pester @pesterParameters

--- a/psake.ps1
+++ b/psake.ps1
@@ -2,7 +2,7 @@
 # Init some things
 Properties {
     # Find the build folder based on build system
-        $ProjectRoot = $ENV:BHProjectPath
+        $ProjectRoot = Convert-Path $ENV:BHProjectPath
         if(-not $ProjectRoot)
         {
             $ProjectRoot = $PSScriptRoot


### PR DESCRIPTION
## Description

This PR adds support for using this module on PowerShell Core (v6) on other OS than Windows.

## Requirements

This PR is based on #78

## Note

This PR does not try to modify any behavior described in `PSDependMap.psd1`