### PR TITLE
Support for TLS1.2

### DIFF
--- a/PSDepend/Private/Get-WebFile.ps1
+++ b/PSDepend/Private/Get-WebFile.ps1
@@ -2,6 +2,7 @@
 Function Get-WebFile {
     param($URL, $Path)
     # We have the info, check for file, download it!
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     $webclient = New-Object System.Net.WebClient
     $webclient.DownloadFile($URL, $Path)
     $webclient.Dispose()

--- a/PSDepend/Private/Get-WebFile.ps1
+++ b/PSDepend/Private/Get-WebFile.ps1
@@ -2,7 +2,7 @@
 Function Get-WebFile {
     param($URL, $Path)
     # We have the info, check for file, download it!
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+	[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
     $webclient = New-Object System.Net.WebClient
     $webclient.DownloadFile($URL, $Path)
     $webclient.Dispose()


### PR DESCRIPTION
PSDepends thrown the following error when using an HTTPS download link:

```
Exception calling "DownloadFile" with "2" argument(s): "The request was aborted: Could not create SSL/TLS secure channel."
At C:\Users\randr\Documents\WindowsPowerShell\Modules\PSDepend\0.2.0\Private\Get-WebFile.ps1:7 char:5
+     $webclient.DownloadFile($URL, $Path)
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException
```

The PSDepends configuration used:
```
@{
    # Set up a mini virtual environment...
    PSDependOptions = @{
        AddToPath = $True
        Target = 'BuildOutput\Modules'
        Parameters = @{
        }
    }

    #...
    
    #File Download
    'https://github.com/AutomatedLab/AutomatedLab/raw/develop/LabSources/Tools/WinSATAPI.dll' = @{
        DependencyType = 'FileDownload'
        Target = '.\DLLs\WinSATAPI.dll'
    }
}
```