### PR TITLE
Target folder is not created, even with -Force parameter. Git.ps1

### DIFF
--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -93,9 +93,10 @@ if($Dependency.Target -and ($Target = (Get-Item $Dependency.Target -ErrorAction 
 }
 else
 {
-if ($Force) {New-Item -ItemType Directory -Name $Dependency.Target -Force | Out-Null
+if ($Force) {
+            New-Item -ItemType Directory -Name (Split-Path $Dependency.Target -Leaf) -Force | Out-Null
             Write-Debug "Target folder $($Dependency.Target) created as -Force switch was specified"
-            $Target = Join-Path $PWD "$($Dependency.Target)"
+            $Target = Join-Path $PWD "$(Split-Path $Dependency.Target -Leaf)"
             }
     else {
         $Target = $PWD.Path

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -93,8 +93,14 @@ if($Dependency.Target -and ($Target = (Get-Item $Dependency.Target -ErrorAction 
 }
 else
 {
-    $Target = $PWD.Path
-    Write-Debug "Target defaulted to current dir: $Target"
+if ($Force) {New-Item -ItemType Directory -Name $Dependency.Target -Force | Out-Null
+            Write-Debug "Target folder $($Dependency.Target) created as -Force switch was specified"
+            $Target = Join-Path $PWD "$($Dependency.Target)"
+            }
+    else {
+        $Target = $PWD.Path
+        Write-Debug "Target defaulted to current dir: $Target"
+        }
 }
 $RepoPath = Join-Path $Target $GitName
 $GottaInstall = $True


### PR DESCRIPTION
When using a Git repository, if target doesn't exist, the dependency is downloaded in the current directory and the error is silenced, affecting the path sctructure of your proyect. Unless you check the $Errors variable, you'll never now what is happening.

However, when using PowerShell Gallery, the bellow piece of code does the work in the Save-Module function:
**When -Force is specified, Path will be created if not available**

        # When -Force is specified, Path will be created if not available.
        if(-not $Force)
        {
            if($Path)
            {
                $destinationPath = Resolve-PathHelper -Path $Path -CallerPSCmdlet $PSCmdlet | Microsoft.PowerShell.Utility\Select-Object -First 1 -ErrorAction Ignore

                if(-not $destinationPath -or -not (Microsoft.PowerShell.Management\Test-path $destinationPath))
                {
                    $errorMessage = ($LocalizedData.PathNotFound -f $Path)
                    ThrowError  -ExceptionName "System.ArgumentException" `
                                -ExceptionMessage $errorMessage `
                                -ErrorId "PathNotFound" `
                                -CallerPSCmdlet $PSCmdlet `
                                -ExceptionObject $Path `
                                -ErrorCategory InvalidArgument
                }

                $PSBoundParameters['Path'] = $destinationPath
            }
            else
            {
                $destinationPath = Resolve-PathHelper -Path $LiteralPath -IsLiteralPath -CallerPSCmdlet $PSCmdlet | Microsoft.PowerShell.Utility\Select-Object -First 1 -ErrorAction Ignore

                if(-not $destinationPath -or -not (Microsoft.PowerShell.Management\Test-Path -LiteralPath $destinationPath))
                {
                    $errorMessage = ($LocalizedData.PathNotFound -f $LiteralPath)
                    ThrowError  -ExceptionName "System.ArgumentException" `
                                -ExceptionMessage $errorMessage `
                                -ErrorId "PathNotFound" `
                                -CallerPSCmdlet $PSCmdlet `
                                -ExceptionObject $LiteralPath `
                                -ErrorCategory InvalidArgument
                }

                $PSBoundParameters['LiteralPath'] = $destinationPath
            }
        }
I propose then to implement the same behaviour in **Git.ps1** script with the following lines:

else
{
if ($Force) {New-Item -ItemType Directory -Name $Dependency.Target -Force | Out-Null
            Write-Debug "Target folder $($Dependency.Target) created as -Force switch was specified"
            $Target = Join-Path $PWD "$($Dependency.Target)"
            }
    else {
        $Target = $PWD.Path
        Write-Debug "Target defaulted to current dir: $Target"
        }
}