### PR TITLE
Support credentials for PSGalleryModule and PSGalleryNuget

### DIFF
--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -69,7 +69,7 @@
     PSGalleryNuget = @{
         Script = 'PSGalleryNuget.ps1'
         Description = 'Install a PowerShell module from the PowerShell Gallery without the PowerShellGet dependency'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     Task = @{

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -9,7 +9,8 @@
             Name: The name for this module
             Version: Used to identify existing installs meeting this criteria, and as RequiredVersion for installation.  Defaults to 'latest'
             Target: Used as 'Scope' for Install-Module.  If this is a path, we use Save-Module with this path.  Defaults to 'AllUsers'
-            AddToPath: If target is used as a path, prepend that path to ENV:PSModulePath
+			AddToPath: If target is used as a path, prepend that path to ENV:PSModulePath
+			Credential: The username and password used to authenticate against the private repository
 
         If you don't have the Nuget package provider, we install it for you
 
@@ -110,7 +111,9 @@ param(
     else
     {
         $Scope = $Dependency.Target
-    }
+	}
+
+	$Credential = $Dependency.Credential
 
     if('AllUsers', 'CurrentUser' -notcontains $Scope)
     {
@@ -156,6 +159,11 @@ if( $Version -and $Version -ne 'latest')
     $Params.add('RequiredVersion',$Version)
 }
 
+if($Credential)
+{
+	$Params.add('Credential', $Credential)
+}
+
 # This code works for both install and save scenarios.
 if($command -eq 'Save')
 {
@@ -194,9 +202,13 @@ if($Existing)
     $FindModuleParams = @{Name = $Name}
     if($Repository) {
         $FindModuleParams.Add('Repository',$Repository)
-    }
+	}
+	if($Credential)
+	{
+		$FindModuleParams.Add('Credential', $Credential)
+	}
 
-    $GetGalleryVersion = { Find-Module @FindModuleParams | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum }
+    $GetGalleryVersion = { Find-Module @FindModuleParams -Verbose | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum }
 
     # Version string, and equal to current
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)

--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -208,7 +208,7 @@ if($Existing)
 		$FindModuleParams.Add('Credential', $Credential)
 	}
 
-    $GetGalleryVersion = { Find-Module @FindModuleParams -Verbose | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum }
+    $GetGalleryVersion = { Find-Module @FindModuleParams | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum }
 
     # Version string, and equal to current
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -50,7 +50,7 @@
             }
         }
 
-        # Install the latest version of PSDeploy on an internal nuget feed, to C:\temp, 
+        # Install the latest version of PSDeploy on an internal nuget feed, to C:\temp,
 
 #>
 [cmdletbinding()]
@@ -93,7 +93,7 @@ param(
         return
     }
 
-if(-not (Get-Command Nuget.exe -ErrorAction SilentlyContinue))
+if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
 {
     Write-Error "PSGalleryNuget requires Nuget.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's NugetPath.  Skipping [$DependencyName]"
 }
@@ -121,7 +121,7 @@ if(Test-Path $ModulePath)
     $ManifestData = Import-LocalizedData -BaseDirectory $ModulePath -FileName "$Name.psd1"
     $ExistingVersion = $ManifestData.ModuleVersion
     $GetGalleryVersion = { ( Find-NugetPackage -Name $Name -PackageSourceUrl $Source -IsLatest ).Version }
-    
+
     # Version string, and equal to current
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)
     {
@@ -134,7 +134,7 @@ if(Test-Path $ModulePath)
         }
         return $null
     }
-    
+
     # latest, and we have latest
     if( $Version -and
         ($Version -eq 'latest' -or $Version -like '') -and
@@ -192,7 +192,8 @@ if($PSDependAction -contains 'Install')
         $NugetParams += '-version', $Version
     }
     $NugetParams = 'install', $Name + $NugetParams
-    Invoke-ExternalCommand nuget.exe -Arguments $NugetParams
+
+	Invoke-ExternalCommand nuget -Arguments $NugetParams
 }
 
 # Conditional import

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -91,7 +91,9 @@ param(
     {
         Write-Error "PSGalleryNuget requires a Dependency Target. Skipping [$DependencyName]"
         return
-    }
+	}
+
+	$Credential = $Dependency.Credential
 
 if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
 {
@@ -120,7 +122,7 @@ if(Test-Path $ModulePath)
     # Thanks to Brandon Padgett!
     $ManifestData = Import-LocalizedData -BaseDirectory $ModulePath -FileName "$Name.psd1"
     $ExistingVersion = $ManifestData.ModuleVersion
-    $GetGalleryVersion = { ( Find-NugetPackage -Name $Name -PackageSourceUrl $Source -IsLatest ).Version }
+    $GetGalleryVersion = { (Find-NugetPackage -Name $Name -PackageSourceUrl $Source -Credential $Credential -IsLatest).Version }
 
     # Version string, and equal to current
     if( $Version -and $Version -ne 'latest' -and $Version -eq $ExistingVersion)

--- a/PSDepend/Private/Find-NugetPackage.ps1
+++ b/PSDepend/Private/Find-NugetPackage.ps1
@@ -12,37 +12,37 @@ function Find-NugetPackage {
         #If specified takes precedence over version
         [switch]$IsLatest,
 
-		[string]$Version,
+        [string]$Version,
 
-		# If specified, gets passed during the Nuget source call
-		[pscredential]$Credential = $null
+        # If specified, gets passed during the Nuget source call
+        [pscredential]$Credential = $null
     )
 
     #Ugly way to do this.  Prefer islatest, otherwise look for version, otherwise grab all matching modules
-	if($IsLatest)
-	{
+    if($IsLatest)
+    {
         Write-Verbose "Searching for latest [$name] module"
         $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name' and IsLatestVersion"
     }
-	elseif($PSBoundParameters.ContainsKey($Version))
-	{
+    elseif($PSBoundParameters.ContainsKey($Version))
+    {
         Write-Verbose "Searching for version [$version] of [$name]"
         $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name' and Version eq '$Version'"
     }
-	else
-	{
+    else
+    {
         Write-Verbose "Searching for all versions of [$name] module"
         $URI = "${PackageSourceUrl}Packages?`$filter=Id eq '$name'"
-	}
+    }
 
-	$headers = @{}
-	if ($null -ne $Credential)
-	{
-		$basicAuthToken = [Convert]::ToBase64String(":$($Credential.GetNetworkCredential().Password)")
+    $headers = @{}
+    if ($null -ne $Credential)
+    {
+        $basicAuthToken = [Convert]::ToBase64String(":$($Credential.GetNetworkCredential().Password)")
 
-		$headers["X-NuGet-ApiKey"] = $Credential.UserName
-		$headers["Authentication"] = "Basic $basicAuthToken"
-	}
+        $headers["X-NuGet-ApiKey"] = $Credential.UserName
+        $headers["Authentication"] = "Basic $basicAuthToken"
+    }
 
     Invoke-RestMethod $URI -Headers $headers |
     Select-Object @{n='Name';ex={$_.title.('#text')}},

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -108,7 +108,17 @@ function Get-Dependency {
                 BuildHelpers = 'latest'
                 PSDeploy = 'latest'
                 InvokeBuild = 'latest'
-            }
+			}
+
+	.PARAMETER Credentials
+		Specifies a hashtable of PSCredentials to use for each dependency that is served from a private feed.
+
+		For example:
+
+			-Credentials @{
+				PrivatePackage = $privateCredentials
+				AnotherPrivatePackage = $morePrivateCredenials
+			}
 
     .LINK
         about_PSDepend
@@ -142,14 +152,17 @@ function Get-Dependency {
         [switch]$Recurse,
 
         [parameter(ParameterSetName='Hashtable')]
-        [hashtable[]]$InputObject
+        [hashtable[]]$InputObject,
 
+		[parameter(ParameterSetName='File')]
+		[parameter(ParameterSetName='Hashtable')]
+		[hashtable]$Credentials
     )
 
     # Helper to pick from global psdependoptions, or return a default
     function Get-GlobalOption {
         param(
-            $Options = $PSDependOptions,
+			$Options = $PSDependOptions,
             $Name,
             $Prefer,
             $Default = $null
@@ -171,12 +184,12 @@ function Get-Dependency {
                 $Output = $Default
             }
         }
-        
+
         # Inject variables
         if( $Name -eq 'Target' -or
             $Name -eq 'Source' -or
             $Name -eq 'PreScripts' -or
-            $Name -eq 'PostScripts')
+			$Name -eq 'PostScripts')
         {
             $Output = Inject-Variable $Output
         }
@@ -238,7 +251,6 @@ function Get-Dependency {
             $DependencyHash = $Dependencies.$Dependency
             $DependencyType = Get-GlobalOption -Name DependencyType
 
-
             # Look simple syntax with helpers in the key first
             If( $DependencyHash -is [string] -and
                 $Dependency -match '::' -and
@@ -259,8 +271,8 @@ function Get-Dependency {
                     Tags = Get-GlobalOption -Name Tags
                     DependsOn = Get-GlobalOption -Name DependsOn
                     PreScripts =  Get-GlobalOption -Name PreScripts
-                    PostScripts =  Get-GlobalOption -Name PostScripts
-                    PSDependOptions = $PSDependOptions
+					PostScripts =  Get-GlobalOption -Name PostScripts
+					PSDependOptions = $PSDependOptions
                     Raw = $null
                 }
             }
@@ -355,7 +367,7 @@ function Get-Dependency {
                         ($Dependency -match '/' -and -not $Dependency.Name -and
                             ($Dependency -is [string] -and $Dependency.split('/').count -eq 2)
                         ) -or
-                        ($DependencyHash.Name -match '/' -and 
+                        ($DependencyHash.Name -match '/' -and
                             ($DependencyHash -is [string] -and $DependencyHash.split('/').count -eq 2)
                         )
                     )
@@ -395,12 +407,28 @@ function Get-Dependency {
                     DependsOn = Get-GlobalOption -Name DependsOn -Prefer $DependencyHash.DependsOn
                     PreScripts = Get-GlobalOption -Name PreScripts -Prefer $DependencyHash.PreScripts
                     PostScripts = Get-GlobalOption -Name PostScripts -Prefer $DependencyHash.PostScripts
-                    PSDependOptions = $PSDependOptions
+					Credential = Resolve-Credential -Name $Dependency
+					PSDependOptions = $PSDependOptions
                     Raw = $DependencyHash
                 }
             }
         }
-    }
+	}
+
+	# Heleper to retrieve the credential for a dependency
+	function Resolve-Credential  {
+		[CmdletBinding()]
+		param (
+			[string]$Name
+		)
+
+		$credential = $null
+		if (($null -ne $Name) -and ($null -ne $Credentials)) {
+			$Credential = $Credentials[$Name]
+		}
+
+		return $credential
+	}
 
     if($PSCmdlet.ParameterSetName -eq 'File')
     {

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -428,7 +428,12 @@ function Get-Dependency {
 
 		$credential = $null
 		if (($null -ne $Name) -and ($null -ne $Credentials)) {
-			$Credential = $Credentials[$Name]
+
+			if ($Credentials.ContainsKey($Name)) {
+				$credential = $Credentials[$Name]
+			} else {
+				Write-Warning "No credential found for the specified name $Name. Was the dependency misconfigured?"
+			}
 		}
 
 		return $credential

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -251,6 +251,8 @@ function Get-Dependency {
             $DependencyHash = $Dependencies.$Dependency
             $DependencyType = Get-GlobalOption -Name DependencyType
 
+			$CredentialName = Get-GlobalOption -Name Credential
+
             # Look simple syntax with helpers in the key first
             If( $DependencyHash -is [string] -and
                 $Dependency -match '::' -and
@@ -298,6 +300,7 @@ function Get-Dependency {
                     DependsOn = Get-GlobalOption -Name DependsOn
                     PreScripts =  Get-GlobalOption -Name PreScripts
                     PostScripts =  Get-GlobalOption -Name PostScripts
+					Credential = Resolve-Credential -Name $CredentialName
                     PSDependOptions = $PSDependOptions
                     Raw = $null
                 }
@@ -392,6 +395,7 @@ function Get-Dependency {
                     $DependencyType = $DependencyHash.DependencyType
                 }
 
+				$CredentialName = Get-GlobalOption -Name Credential -Prefer $DependencyHash.Credential
                 [pscustomobject]@{
                     PSTypeName = 'PSDepend.Dependency'
                     DependencyFile = $DependencyFile
@@ -407,7 +411,7 @@ function Get-Dependency {
                     DependsOn = Get-GlobalOption -Name DependsOn -Prefer $DependencyHash.DependsOn
                     PreScripts = Get-GlobalOption -Name PreScripts -Prefer $DependencyHash.PreScripts
                     PostScripts = Get-GlobalOption -Name PostScripts -Prefer $DependencyHash.PostScripts
-					Credential = Resolve-Credential -Name $Dependency
+					Credential = Resolve-Credential -Name $CredentialName
 					PSDependOptions = $PSDependOptions
                     Raw = $DependencyHash
                 }

--- a/PSDepend/Public/Invoke-PSDepend.ps1
+++ b/PSDepend/Public/Invoke-PSDepend.ps1
@@ -44,7 +44,7 @@ Function Invoke-PSDepend {
 
     .PARAMETER Test
         Run tests for dependencies we find.
-        
+
         Appends a 'DependencyExists' property indicating whether the dependency exists by default
         Specify Quiet to simply return $true or $false depending on whether all dependencies exist
 
@@ -59,8 +59,18 @@ Function Invoke-PSDepend {
     .PARAMETER Target
         If specified, override the target in the PSDependOptions or Dependency.
 
-    .PARAMETER Import 
-        If the dependency supports it, import it
+    .PARAMETER Import
+		If the dependency supports it, import it
+
+	.PARAMETER Credentials
+		Specifies a hashtable of PSCredentials to use for each dependency that is served from a private feed.
+
+		For example:
+
+			-Credentials @{
+				PrivatePackage = $privateCredentials
+				AnotherPrivatePackage = $morePrivateCredenials
+			}
 
     .EXAMPLE
         Invoke-PSDepend
@@ -144,7 +154,11 @@ Function Invoke-PSDepend {
 
         [switch]$Force,
 
-        [String]$Target
+		[String]$Target,
+
+		[parameter(ParameterSetName = 'installimport-file')]
+        [parameter(ParameterSetName = 'installimport-hashtable')]
+        [hashtable]$Credentials
     )
     Begin
     {
@@ -198,7 +212,11 @@ Function Invoke-PSDepend {
         if($PSBoundParameters.ContainsKey('Tags'))
         {
             $GetPSDependParams.Add('Tags',$Tags)
-        }
+		}
+
+		if ($null -ne $Credentials) {
+			$GetPSDependParams.Add('Credentials', $Credentials)
+		}
 
         # Handle Dependencies
         $Dependencies = Get-Dependency @GetPSDependParams

--- a/Tests/DependFiles/psgallerymodule.multiplecredentials.depend.psd1
+++ b/Tests/DependFiles/psgallerymodule.multiplecredentials.depend.psd1
@@ -1,0 +1,10 @@
+@{
+	'imaginary' = @{
+		Version = 'latest'
+		Credential = 'imaginaryCreds'
+	}
+	'other' = @{
+		Version = 'latest'
+		Credential = 'otherCreds'
+	}
+}

--- a/Tests/DependFiles/psgallerymodule.withcredentials.depend.psd1
+++ b/Tests/DependFiles/psgallerymodule.withcredentials.depend.psd1
@@ -1,0 +1,6 @@
+@{
+	'imaginary' = @{
+		Version = 'latest'
+		Credential = 'imaginaryCreds'
+	}
+}

--- a/Tests/DependFiles/psgallerynuget.latestversionwithcredential.depend.psd1
+++ b/Tests/DependFiles/psgallerynuget.latestversionwithcredential.depend.psd1
@@ -1,0 +1,11 @@
+@{
+	'jenkins' = @{
+		DependencyType = 'PSGalleryNuget'
+		Version = 'latest'
+		Target = 'TestDrive:/PSDependPesterTest'
+		Parameters = @{
+			Force = $true
+		}
+		Credential = "imaginaryCreds"
+	}
+}

--- a/Tests/DependFiles/psgallerynuget.withcredentials.psd1
+++ b/Tests/DependFiles/psgallerynuget.withcredentials.psd1
@@ -1,0 +1,11 @@
+@{
+	'jenkins' = @{
+		DependencyType = 'PSGalleryNuget'
+		Version = '1.2.5'
+		Target = 'TestDrive:/PSDependPesterTest'
+		Parameters = @{
+			Force = $true
+		}
+		Credential = 'imaginaryCreds'
+	}
+}

--- a/Tests/DependFiles/savemodule.withcredentials.depend.psd1
+++ b/Tests/DependFiles/savemodule.withcredentials.depend.psd1
@@ -1,0 +1,6 @@
+@{
+	'jenkins' = @{
+		target = 'TestDrive:/PSDependPesterTest'
+		credential = 'imaginaryCreds'
+	}
+}


### PR DESCRIPTION
This is an update of the functionality written by @alphakilo45 to address issue #94 .

As part of this change I also modified barriers to using the nuget based code cross platform. I have successfully tested both PSGalleryModule and PSGalleryNuget dependencies in PowerShell Core on OSX.