### PR TITLE
Explicitly cast versions for comparison

### DIFF
--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -227,7 +227,7 @@ if($Existing)
     # latest, and we have latest
     if( $Version -and
         ($Version -eq 'latest' -or $Version -like '') -and
-        ($GalleryVersion = (& $GetGalleryVersion)) -le $ExistingVersion
+        [System.Version]($GalleryVersion = (& $GetGalleryVersion)) -le [System.Version]$ExistingVersion
     )
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and PSGallery version [$GalleryVersion]"


### PR DESCRIPTION
Resolves #66

* Issue only observed when module version format is inconsistent: (eg: [major].[minor] in one version and semver in another)