### PR TITLE
Git Dependency Handler adapted

### DIFF
--- a/PSDepend/PSDependMap.psd1
+++ b/PSDepend/PSDependMap.psd1
@@ -33,7 +33,7 @@
     Git = @{
         Script = 'Git.ps1'
         Description = 'Clone a git repository'
-        Supports = 'windows'
+        Supports = 'windows', 'core', 'macos', 'linux'
     }
 
     GitHub = @{

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -214,7 +214,7 @@ if($Dependency.AddToPath)
     Add-ToItemCollection -Reference Env:\PSModulePath -Item (Get-Item $Target).FullName
     
     Write-Verbose "Setting PATH to`n$($RepoPath, $env:PATH -join ';' | Out-String)"
-    Add-ToItemCollection -Reference Env:\Path -Item (Get-Item $Target).FullName
+    Add-ToItemCollection -Reference Env:\PATH -Item (Get-Item $Target).FullName
 }
 
 $ToImport = $Target


### PR DESCRIPTION
With regard to  #59 

By adjusting the reference to the path variable and adjusting the support property in the [DependMap.psd1](https://github.com/RamblingCookieMonster/PSDepend/blob/master/PSDepend/PSDependMap.psd1) file, the Dependency Handler Git can also run on *nix systems.