### PR TITLE
Add support for exe in nuget package

### DIFF
--- a/PSDepend/PSDependScripts/Nuget.ps1
+++ b/PSDepend/PSDependScripts/Nuget.ps1
@@ -75,6 +75,7 @@ param(
     [ValidateSet('Test', 'Install')]
     [string[]]$PSDependAction = @('Install'),
 
+    [Alias('DLLName')]
     [string]$Name
 )
 # Extract data from Dependency


### PR DESCRIPTION
Previously only a Nuget package with a dll was supported. This adds support for an exe in a Nuget package. Also changed the parameter $Name to be more syntactically correct since exe and dll is now supported.

@scrthq I would appreciate you taking a look to see if anything needs changed.