### PR TITLE
add ps version constraint for semanticversion class

### DIFF
--- a/PSDepend/Private/SemanticVersion.ps1
+++ b/PSDepend/Private/SemanticVersion.ps1
@@ -687,4 +687,6 @@ namespace System.Management.Automation
 }
 '@
 
-Add-Type -TypeDefinition $code
+if ($PSVersionTable.PSVersion.Major -lt 6) {
+  Add-Type -TypeDefinition $code
+}


### PR DESCRIPTION
add ps version constraint for semanticversion class to be lower than psv6 or else we have a conflict with native class.

We have this error in Azure DevOps pipelines since the new code:

```
Line |
 154 |    Import-Module PSDepend
     |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Failed to import function /agent/_work/1/s/out/modulecache/PSDepend/0.3.4/Private/SemanticVersion.ps1: (15,68): error CS0436: The type 'SemanticVersion' in '' conflicts with the imported type 'SemanticVersion' in 'System.Management.Automation, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. Using the type defined in ''.     public sealed class SemanticVersion : IComparable, IComparable<SemanticVersion>, IEquatable<SemanticVersion>                                                                    ^ 
```