### PR TITLE
Made Bootstrap-Nuget also run on PS Core+Windows

### DIFF
--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -27,7 +27,7 @@
             $Value = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Value)
             Set-Variable -Name $Name -Value $Value
         }
-    if(Test-PlatformSupport -Support 'windows') {
+    if(Test-PlatformSupport -Support 'windows','core') {
         BootStrap-Nuget -NugetPath $NuGetPath
     }
 


### PR DESCRIPTION
Simple change so that Bootstrap-Nuget runs on e.g. PowerShell 7 on a Windows machine.