### PR TITLE
fix(Import-PSDependModule): Sanitize version string used for Import-Module

### DIFF
--- a/PSDepend/Private/Import-PSDependModule.ps1
+++ b/PSDepend/Private/Import-PSDependModule.ps1
@@ -16,7 +16,10 @@
                 Force = $true
             }
             if ($Version -and $Version -ne 'latest') {
-                $importParams.add('RequiredVersion',$Version)
+                # Sanitize version string. The RequiredVersion parameter is a System.Version and
+                # doesn't know anything about pre-release tags.
+                $BaseVersion = ($Version -split '-')[0]
+                $importParams.add('RequiredVersion',$BaseVersion)
             }
             Import-Module @importParams
         }


### PR DESCRIPTION
This commit fixes one particular issue out of two identified issues.

The first identified issue is that when initially "getting" a dependency, it does not seem to be imported. (I may be mistaken on this point, but read on.) The second issue, and the one this commit addresses, is that upon a subsequent run of PSDepend, the now "installed" module is attempted to be imported, and this fails in the case of modules whose PSDepend specification's version string includes a pre-release version tag.

For example, the following spec:

```powershell
@{
    'PSResourceGet' = @{
        Name = 'Micrsooft.PowerShell.PSResourceGet'
        Version = 'latest'
        Parameters = @{
            AllowPreRelease = $true
        }
    }
}
```

The first time you run PSDepend, everything "works" fine. The reason I say that an "install" is performed but not an import is because there are no errors when running this the first time. But using this same configuration, running PSDepend a subsequent time results in the following error:

```text
Checking for and installing the latest versions of the build system dependencies...
WARNING: Access to the path 'D:\src\git\MyProject\build\deps\Microsoft.PowerShell.PSResourceGet\0.5.24' is denied.
Save-Package: Unable to save the module 'Microsoft.PowerShell.PSResourceGet'.
Import-Module: C:\Users\me\Documents\PowerShell\Modules\PSDepend\0.3.8\Private\Import-PSDependModule.ps1:21
Line |
  21 |              Import-Module @importParams
     |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The specified module 'D:\src\git\MyProject\build\deps\Microsoft.PowerShell.PSResourceGet' was not loaded because no valid module
     | file was found in any module directory.
```

The issue here is that now that the module is "installed", the version string, as specified in the PSDepend spec, is passed directly to Import-Module via Import-PSDependModule. It is necessary to sanitize the version string to remove any pre-release tags since Import-Module doesn't know anything about pre-release versions. The RquiredVersion parameter is a `System.Version` from the .NET BCL and is a Microsoft-proprietary version number format, not a SemVer string.

This commit fixes this subsequent "import issue".

Fixes #132 