### PR TITLE
docs: update README and examples for PowerShellOrg ownership

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [ramblingcookiemonster]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'PSDepend/**'
+      - 'Tests/**'
+      - 'build.ps1'
+      - 'psake.ps1'
+  pull_request:
+    paths:
+      - 'PSDepend/**'
+      - 'Tests/**'
+      - 'build.ps1'
+      - 'psake.ps1'
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test
+        shell: pwsh
+        run: ./build.ps1 -Task Test
+      - name: Upload Test Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: testResults-${{ matrix.os }}
+          path: ./Tests/out/testResults.xml
+
+  publish-test-results:
+    name: Publish Test Results
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - uses: EnricoMi/publish-unit-test-result-action@v2
+        with:
+          files: artifacts/**/*.xml

--- a/Examples/HowDoI.md
+++ b/Examples/HowDoI.md
@@ -1,10 +1,10 @@
 # How Do I
 
-Rather than scour the documentation, which may or may not be scenario focused, here is a quick list of common scenarios and recipes.
+Common scenarios and recipes for working with PSDepend.
 
 ## Specify global defaults
 
-You can use the special PSDependOptions node for default options:
+Use the special `PSDependOptions` node to set defaults that apply to all dependencies in the file:
 
 ```powershell
 @{
@@ -13,29 +13,29 @@ You can use the special PSDependOptions node for default options:
         DependencyType = 'PSGalleryNuget'
     }
 
-    'PSDeploy' = 'latest'
-    'BuildHelpers' = 'latest'
-    'Pester' = 'latest'
-    'InvokeBuild' = 'latest'
+    'PSDeploy'      = 'latest'
+    'BuildHelpers'  = 'latest'
+    'Pester'        = 'latest'
+    'InvokeBuild'   = 'latest'
 }
 ```
 
-This downloads any dependency without an explicit override to `C:\MyProject`, using PSGalleryNuget
+All dependencies without an explicit override will be downloaded to `C:\MyProject` using `PSGalleryNuget`.
 
-You can specify the following in PSDependOptions:
+The following properties can be set in `PSDependOptions`:
 
-* Parameters
-* Source
-* Target
-* AddToPath
-* Tags
-* DependsOn
-* PreScripts
-* PostScripts
+- `Parameters`
+- `Source`
+- `Target`
+- `AddToPath`
+- `Tags`
+- `DependsOn`
+- `PreScripts`
+- `PostScripts`
 
-## Specify global defaults, with overrides
+## Override a global default for specific dependencies
 
-You can override global defaults:
+Individual dependencies can override any value set in `PSDependOptions`:
 
 ```powershell
 @{
@@ -44,7 +44,7 @@ You can override global defaults:
         DependencyType = 'PSGalleryNuget'
     }
 
-    'PSDeploy' = 'latest'
+    'PSDeploy'     = 'latest'
     'BuildHelpers' = 'latest'
     'Pester' = @{
         Target = 'C:\sc'
@@ -53,43 +53,34 @@ You can override global defaults:
 }
 ```
 
-In this example, all modules are downloaded to `C:\MyProject`, apart from Pester, which has an override.
+All modules install to `C:\MyProject` except `Pester`, which installs to `C:\sc`.
 
-## Specify one target for all dependencies
-
-You can certainly set a target on every single dependency, or:
+## Set a single target for all dependencies
 
 ```powershell
 @{
     PSDependOptions = @{
-        Target = 'C:\MyTarget'    # <<<<<<<
+        Target = 'C:\MyTarget'
     }
 
     PSDeploy = 'latest'
-    'darkoperator/ADAudit' = 'dev'
+    'PowerShellOrg/PSDepend' = 'master'
 }
 ```
 
-Just specify a target under PSDependOptions, this will be used as the default target unless you override it.
-
-## Specify one target for most dependencies
-
-If you want to specify one target for most dependencies, with a few exceptions:
+## Set a default target with per-dependency overrides
 
 ```powershell
 @{
     PSDependOptions = @{
-        Target = 'C:\MyTarget'    # <<<<<<<
+        Target = 'C:\MyTarget'
     }
 
-    PSDeploy = 'latest'
-    PSSlack = 'latest'
+    PSDeploy  = 'latest'
+    PSSlack   = 'latest'
     PSJira = @{
         Target = 'C:\OtherTarget'
     }
-    'darkoperator/ADAudit' = 'dev'
+    'PowerShellOrg/PSDepend' = 'master'
 }
 ```
-
-
-

--- a/Examples/ModuleDependencies.md
+++ b/Examples/ModuleDependencies.md
@@ -1,31 +1,30 @@
 # Handling Module Dependencies
 
-The PowerShellGet functions are pretty cool - if you run `Install-Module XYZ`, you'll get XYZ, and any modules defined in XYZ's `RequiredModules` manifest section.  But... What if the gallery isn't your only dependency source? 
+`Install-Module` handles dependencies declared in a module manifest's `RequiredModules` section, but it only covers the PowerShell Gallery. PSDepend lets you declare dependencies from multiple sources — Gallery modules, Git repos, and file downloads — in one place.
 
-This is a quick demo illustrating a quick way to pull down module dependencies.  You might run this during an automated build, or even at run time given that this should be idempotent.
+This walkthrough demonstrates embedding a `requirements.psd1` in a module so dependencies are resolved automatically on import.
 
 ## Set Up the Demo Module
 
-We'll set up a demo module in C:\MyModule.
-
 ```powershell
-# Set up a new module.  We'll create a basic skeleton that does nothing.
-mkdir C:\MyModule -force
+mkdir C:\MyModule -Force
+
 New-ModuleManifest -Path C:\MyModule\MyModule.psd1 `
                    -RootModule 'MyModule.psm1' `
                    -FunctionsToExport Test-PSDependExample `
                    -CmdletsToExport $null `
                    -VariablesToExport $null `
                    -AliasesToExport $null
-                   
+
 Set-Content -Path C:\MyModule\MyModule.psm1 @'
-# Load up dependencies!
-Invoke-PSDepend -Path $PSScriptRoot\requirements.psd1 -Target $PSScriptRoot\Dependencies -Install -Force
+# Resolve dependencies on module load
+Invoke-PSDepend -Path $PSScriptRoot\Requirements.psd1 -Target $PSScriptRoot\Dependencies -Install -Force
 
 Import-Module Posh-SSH
+
 Function Test-PSDependExample {
-    Get-ChildItem $PSScriptRoot\Dependencies -Recurse -Depth 1 | Select -ExpandProperty FullName
-    Get-Module | Select Name, Path
+    Get-ChildItem $PSScriptRoot\Dependencies -Recurse -Depth 1 | Select-Object -ExpandProperty FullName
+    Get-Module | Select-Object Name, Path
 }
 '@
 
@@ -38,22 +37,17 @@ Set-Content C:\MyModule\Requirements.psd1 -Value @'
         }
     }
 
-    # Grab some modules
     'Posh-SSH' = 'latest'
 
-    # Clone a repo
-    'ramblingcookiemonster/PowerShell' = 'master'
+    'PowerShellOrg/PSDepend' = 'master'
 
-    # Download a file
     'AzCopy_Download' = @{
         Name = 'azcopy.msi'
         DependencyType = 'FileDownload'
         Source = 'http://aka.ms/downloadazcopy'
         DependsOn = 'Posh-SSH'
     }
-    
-    # Ugly bootstrap install for azcopy to illustrate 'command' type
-    # Thanks to https://github.com/Microsoft/PartsUnlimited/blob/master/env/PartsUnlimited.Environment/PartsUnlimited.Environment/Scripts/Install-AzCopy.ps1
+
     'AzCopy_Install' = @{
         DependencyType = 'Command'
         Source = '$DepFolder = "$DependencyFolder\Dependencies"',
@@ -69,73 +63,68 @@ Set-Content C:\MyModule\Requirements.psd1 -Value @'
 '@
 ```
 
-We're ready to go! Let's look at the folder before we start:
+## Run It
 
-## Fun With Dependencies
-
-```
-PS C:\> dir C:\MyModule -Recurse | Select FullName
-
-FullName                     
---------                     
-C:\MyModule\MyModule.psd1    
-C:\MyModule\MyModule.psm1    
-C:\MyModule\Requirements.psd1 
-```
-
-Awesome, so I have a module, and a requirements file that it kicks off on load.  Let's load it up and see what happens!
+Starting from a clean module folder:
 
 ```
-PS C:\> Measure-Command {Import-Module C:\MyModule}
+PS C:\> Get-ChildItem C:\MyModule -Recurse | Select-Object FullName
+
+FullName
+--------
+C:\MyModule\MyModule.psd1
+C:\MyModule\MyModule.psm1
+C:\MyModule\Requirements.psd1
+```
+
+Import the module — PSDepend resolves all dependencies on first load:
+
+```
+PS C:\> Measure-Command { Import-Module C:\MyModule }
 
 ...
-Seconds           : 11
+Seconds : 11
+```
 
-PS C:\> Get-ChildItem C:\MyModule\Dependencies -Recurse -Directory -Depth 1 | Select FUllname
+Initial load time depends on bandwidth. Subsequent imports are fast because PSDepend skips dependencies that are already present:
 
-FullName                     
---------     
+```
+PS C:\> Measure-Command { Import-Module C:\MyModule -Force }
+
+...
+Seconds : 3
+```
+
+Confirm the dependencies were installed:
+
+```
+PS C:\> Get-ChildItem C:\MyModule\Dependencies -Recurse -Directory -Depth 1 | Select-Object FullName
+
+FullName
+--------
 C:\MyModule\Dependencies\AzCopy
 C:\MyModule\Dependencies\Posh-SSH
-C:\MyModule\Dependencies\PowerShell
+C:\MyModule\Dependencies\PSDepend
 C:\MyModule\Dependencies\Posh-SSH\1.7.6
-C:\MyModule\Dependencies\PowerShell\.build
-C:\MyModule\Dependencies\PowerShell\Images
-C:\MyModule\Dependencies\PowerShell\Tests
+C:\MyModule\Dependencies\PSDepend\.build
 ```
 
-Not bad!  This really depends on bandwidth, I ended up between 11 and 30 seconds for initial runs.  What if we import the module again?
+Confirm the modules loaded from the local dependencies folder:
 
 ```
-PS C:\> Measure-Command {Import-Module C:\MyModule -force}
+PS C:\> Test-PSDependExample
 
-...
-Seconds           : 3
-
-```
-
-That's it!  Every time the module is imported, we see the dependencies and skip their installs.  If we move to another system, the initial launch will pull down our dependencies.
-
-Oh, and to show that we imported those modules, we can run the dummy function from the module that lists their commands:
-
-```
-PS C:\Windows\system32> Test-PSDependExample
-
-# Filtered out some output by hand for readability
 C:\MyModule\Dependencies\AzCopy
 C:\MyModule\Dependencies\Posh-SSH
-C:\MyModule\Dependencies\PowerShell
+C:\MyModule\Dependencies\PSDepend
 C:\MyModule\Dependencies\azcopy.msi
 C:\MyModule\Dependencies\AzCopy\AzCopy.exe
-Name                            Path                                                                             
-----                            ----                                                                             
-MyModule                        C:\MyModule\MyModule.psm1                                                        
-Posh-SSH                        C:\Program Files\WindowsPowerShell\Modules\Posh-SSH\1.7.5\Posh-SSH.psd1          
+
+Name      Path
+----      ----
+MyModule  C:\MyModule\MyModule.psm1
+Posh-SSH  C:\MyModule\Dependencies\Posh-SSH\1.7.6\Posh-SSH.psd1
 ...
 ```
 
-So!  If you need a re-usable, functional, self-documenting way to pull in module dependencies, and performance isn't a top concern, PSDepend might fit the bill.
-
-Huge thanks to Mike Walker for the idea : )
-
-Cheers!
+This pattern gives you a self-contained, repeatable module that pulls its own dependencies on first use — useful for build scripts, CI pipelines, or any module you want to work reliably across machines without a separate setup step.

--- a/Examples/VirtualEnvironment.md
+++ b/Examples/VirtualEnvironment.md
@@ -1,94 +1,87 @@
-# Creating a Virtual Environment of Sorts
+# Creating a Virtual Environment
 
-This is a quick demo illustrating a "virtual-environment-light" scenario.
+This walkthrough demonstrates a "virtual environment" scenario — pulling down dependencies into a project folder and importing them directly, independent of any other versions installed on the system.
 
-We pull down some dependencies and import them directly, regardless of whether we have different versions elsewhere on the system
-
-## Set Up A Demo "Project"
+## Set Up a Demo Project
 
 ```powershell
-# Set up a project folder, and a requirements.psd1
-mkdir C:\ProjectX -force
+mkdir C:\ProjectX -Force
 Set-Content C:\ProjectX\Requirements.psd1 -Value @'
 @{
     PSDependOptions = @{
-        Target = '$DependencyFolder' # I want all my dependencies installed here
-        AddToPath = $True            # I want to prepend project to $ENV:Path and $ENV:PSModulePath
+        Target = '$DependencyFolder' # Install all dependencies here
+        AddToPath = $True            # Prepend project folder to $ENV:Path and $ENV:PSModulePath
     }
 
-    # Grab some modules
-    PSSlack = 'latest'
+    # Gallery modules
+    PSSlack     = 'latest'
     ImportExcel = 'latest'
-    'Posh-SSH' = 'latest'
+    'Posh-SSH'  = 'latest'
 
     # Clone a git repo
-    'ramblingcookiemonster/PowerShell' = 'master'
+    'PowerShellOrg/PSDepend' = 'master'
 
     # Download a file
-    'psrabbitmq.dll' = @{
+    'RabbitMQ.Client.dll' = @{
         DependencyType = 'FileDownload'
-        Source = 'https://github.com/RamblingCookieMonster/PSRabbitMq/raw/master/PSRabbitMq/lib/RabbitMQ.Client.dll'
+        Source = 'https://github.com/PowerShellOrg/PSDepend/raw/master/PSDepend/PSDepend.psd1'
     }
 }
 '@
 ```
 
-We're ready to go!
-
-## Test and Create the Virtual Environment
+## Test and Install
 
 ```powershell
 Import-Module PSDepend
 
-# Do I have my dependencies already? Nope
-Invoke-PSDepend -Path C:\ProjectX -Test | Select Dependency*
+# Check whether dependencies are already in place
+Invoke-PSDepend -Path C:\ProjectX -Test | Select-Object Dependency*
 <#
-    DependencyFile                DependencyName                   DependencyType  DependencyExists
-    --------------                --------------                   --------------  ----------------
-    C:\ProjectX\Requirements.psd1 ImportExcel                      PSGalleryModule            False
-    C:\ProjectX\Requirements.psd1 Posh-SSH                         PSGalleryModule            False
-    C:\ProjectX\Requirements.psd1 PSSlack                          PSGalleryModule            False
-    C:\ProjectX\Requirements.psd1 ramblingcookiemonster/PowerShell Git                        False
-    C:\ProjectX\Requirements.psd1 psrabbitmq.dll                   FileDownload               False
+    DependencyFile                DependencyName           DependencyType  DependencyExists
+    --------------                --------------           --------------  ----------------
+    C:\ProjectX\Requirements.psd1 ImportExcel              PSGalleryModule            False
+    C:\ProjectX\Requirements.psd1 Posh-SSH                 PSGalleryModule            False
+    C:\ProjectX\Requirements.psd1 PSSlack                  PSGalleryModule            False
+    C:\ProjectX\Requirements.psd1 PowerShellOrg/PSDepend   Git                        False
+    C:\ProjectX\Requirements.psd1 RabbitMQ.Client.dll      FileDownload               False
 #>
 
-# Install them...
+# Install all dependencies
 Invoke-PSDepend -Path C:\ProjectX -Force
 
-# Test again, this time just get a true or false:
-Invoke-PSDepend -Path C:\ProjectX\requirements.psd1 -Test -Quiet
+# Verify
+Invoke-PSDepend -Path C:\ProjectX\Requirements.psd1 -Test -Quiet
 # True
 
-# Just to be sure...
-dir C:\ProjectX
-<#  Yep!
-    Mode                LastWriteTime         Length Name                                                                                                        
-    ----                -------------         ------ ----                                                                                                        
-    d-----        8/30/2016  10:48 AM                ImportExcel                                                                                                 
-    d-----        8/30/2016  10:48 AM                Posh-SSH                                                                                                    
-    d-----        8/30/2016  10:48 AM                PowerShell                                                                                                  
-    d-----        8/30/2016  10:48 AM                PSSlack                                                                                                     
-    -a----        8/30/2016  10:48 AM         248320 RabbitMQ.Client.dll                                                                                         
-    -a----        8/30/2016  10:48 AM            627 Requirements.psd1  
-#>
-
-# Oh, let's import them
-Invoke-PSDepend -Path C:\ProjectX\requirements.psd1 -Import -Force
-
-# Did they import?
-Get-Module PSSlack, ImportExcel, Posh-SSH | Select Name, Path
+# Confirm files are present
+Get-ChildItem C:\ProjectX
 <#
-    Name        Path                                          
-    ----        ----                                          
-    ImportExcel C:\ProjectX\ImportExcel\2.2.7\ImportExcel.psm1
-    Posh-SSH    C:\ProjectX\Posh-SSH\1.7.6\Posh-SSH.psd1      
-    PSSlack     C:\ProjectX\PSSlack\0.0.15\PSSlack.psm1 
+    Mode                LastWriteTime         Length Name
+    ----                -------------         ------ ----
+    d-----        8/30/2016  10:48 AM                ImportExcel
+    d-----        8/30/2016  10:48 AM                Posh-SSH
+    d-----        8/30/2016  10:48 AM                PSDepend
+    d-----        8/30/2016  10:48 AM                PSSlack
+    -a----        8/30/2016  10:48 AM         248320 RabbitMQ.Client.dll
+    -a----        8/30/2016  10:48 AM            627 Requirements.psd1
 #>
 
+# Import all dependencies
+Invoke-PSDepend -Path C:\ProjectX\Requirements.psd1 -Import -Force
 
-# Lastly, did our PSModulePath and Path get updated?
+# Confirm modules loaded from the project folder
+Get-Module PSSlack, ImportExcel, Posh-SSH | Select-Object Name, Path
+<#
+    Name        Path
+    ----        ----
+    ImportExcel C:\ProjectX\ImportExcel\2.2.7\ImportExcel.psm1
+    Posh-SSH    C:\ProjectX\Posh-SSH\1.7.6\Posh-SSH.psd1
+    PSSlack     C:\ProjectX\PSSlack\0.0.15\PSSlack.psm1
+#>
+
+# Confirm $env:Path and $env:PSModulePath were updated
 $env:Path -split ';'
-
 <#
     C:\ProjectX
     C:\Windows\system32
@@ -96,13 +89,11 @@ $env:Path -split ';'
 #>
 
 $env:PSModulePath -split ';'
-
 <#
     C:\ProjectX
-    C:\Users\wframe\Documents\WindowsPowerShell\Modules
+    C:\Users\<username>\Documents\WindowsPowerShell\Modules
+    ...
 #>
 ```
 
-That's about it!  You could use code similar to this to set up a virtual environment of sorts, with certain modules pre-loaded, and certain paths and psmodulepaths taking precedence for the current session.
-
-Yes, I know this isn't really a virtual environment, just seemed like the quickest way to get the idea across : )
+This pattern lets you set up an isolated dependency folder for a project, with those paths taking precedence over system-wide installations for the current session.

--- a/README.md
+++ b/README.md
@@ -1,98 +1,72 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/4mwhsx9pkfpc1j48/branch/master?svg=true)](https://ci.appveyor.com/project/RamblingCookieMonster/psdepend/branch/master)
+[![CI](https://github.com/PowerShellOrg/PSDepend/actions/workflows/ci.yml/badge.svg)](https://github.com/PowerShellOrg/PSDepend/actions/workflows/ci.yml)
 
-PSDepend
-========
+# PSDepend
 
-This is a simple PowerShell dependency handler.  You might loosely compare it to `bundle install` in the Ruby world or `pip install -r requirements.txt` in the Python world.
+PSDepend is a PowerShell dependency handler. Define your dependencies in a simple `.psd1` file and let `Invoke-PSDepend` install them — similar to `pip install -r requirements.txt` or `bundle install`.
 
-PSDepend allows you to write simple requirements.psd1 files that describe what dependencies you need, which you can invoke with `Invoke-PSDepend`
-
-**WARNING**:
-
-* Minimal testing.  This is in my backlog, but PRs would be welcome!
-* This borrows quite heavily from PSDeploy.  There may be leftover components that haven't been adapted, have been improperly adapted, or shouldn't have been adapted
-* Would love ideas, feedback, pull requests, etc., but if you rely on this, consider pinning a specific version to avoid hitting breaking changes.
-
-## Getting Started
-
-### Installing PSDepend
+## Installing
 
 ```powershell
-# PowerShell 5
+# PowerShell 7+ (recommended)
+Install-PSResource PSDepend
+
+# PowerShell 5.1
 Install-Module PSDepend
 
-# PowerShell 3 or 4, curl|bash bootstrap. Read before running something like this : )
-iex (new-object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/RamblingCookieMonster/PSDepend/master/Examples/Install-PSDepend.ps1')
+# Manual
+# Download and unblock the repository zip, then extract the PSDepend folder
+# to a module path (e.g. $env:USERPROFILE\Documents\WindowsPowerShell\Modules\)
+```
 
-# Git
-    # Download the repository
-    # Unblock the zip
-    # Extract the PSDepend folder to a module path (e.g. $env:USERPROFILE\Documents\WindowsPowerShell\Modules\)
+## Quick Start
 
-# Import and start exploring
+```powershell
 Import-Module PSDepend
 Get-Command -Module PSDepend
 Get-Help about_PSDepend
 ```
 
-### Example Scenarios
-
-In-depth:
-
-* [Creating a virtual-environment-light](/Examples/VirtualEnvironment.md)
-* [Handling module dependencies](/Examples/ModuleDependencies.md)
-
-Recipes:
-
-* [How Do I...](/Examples/HowDoI.md)
-
 ## Defining Dependencies
 
-Store dependencies in a PowerShell data file, and use *.depend.psd1 or requirements.psd1 to allow Invoke-PSDepend to find your files for you.
-
-What does a dependency file look like?
+Store dependencies in a PowerShell data file named `*.depend.psd1` or `requirements.psd1`. `Invoke-PSDepend` will find these files automatically.
 
 ### Simple syntax
-
-Here's the simplest syntax.  If this meets your needs, you can stop here:
 
 ```powershell
 @{
     psake        = 'latest'
     Pester       = 'latest'
-    BuildHelpers = '0.0.20'  # I don't trust this Warren guy...
-    PSDeploy     = '0.1.21'  # Maybe pin the version in case he breaks this...
+    BuildHelpers = '0.0.20'
+    PSDeploy     = '0.1.21'
 
-    'RamblingCookieMonster/PowerShell' = 'master'
+    'PowerShellOrg/PSDepend' = 'master'
 }
 ```
 
-And what PSDepend sees:
+PSDepend infers `PSGalleryModule` for bare names and `GitHub` for `owner/repo` entries:
 
 ```
-DependencyName                   DependencyType  Version Tags
---------------                   --------------  ------- ----
-psake                            PSGalleryModule latest
-BuildHelpers                     PSGalleryModule 0.0.20
-Pester                           PSGalleryModule latest
-RamblingCookieMonster/PowerShell GitHub          master
-PSDeploy                         PSGalleryModule 0.1.21
+DependencyName          DependencyType  Version Tags
+--------------          --------------  ------- ----
+psake                   PSGalleryModule latest
+BuildHelpers            PSGalleryModule 0.0.20
+Pester                  PSGalleryModule latest
+PowerShellOrg/PSDepend  GitHub          master
+PSDeploy                PSGalleryModule 0.1.21
 ```
 
-There's a bit more behind the scenes - we assume you want PSGalleryModules or GitHub repos unless you specify otherwise, and we hide a few dependency properties.
-
-We can also indicate the dependency type more explicitly if desired:
+You can also specify the dependency type explicitly:
 
 ```powershell
 @{
-    'PSGalleryModule::InvokeBuild' = 'latest'
-    'GitHub::RamblingCookieMonster/PSNeo4j' = 'master'
+    'PSGalleryModule::InvokeBuild'       = 'latest'
+    'GitHub::PowerShellOrg/PSDepend'     = 'master'
 }
 ```
 
 ### Flexible syntax
 
-What else can we put in a dependency?  Here's an example using a more flexible syntax.  You can mix and match.
+For more control, use the hashtable syntax. You can mix and match styles within the same file:
 
 ```powershell
 @{
@@ -125,14 +99,11 @@ What else can we put in a dependency?  Here's an example using a more flexible s
 }
 ```
 
-This example illustrates using a few different dependency types, using DependsOn to sort things (e.g. some_task runs after nuget), tags, and other options.
-
-You can inspect the full output as needed.  For example:
+To inspect the full dependency output:
 
 ```powershell
-# List the dependencies, get the third item, show all props
-$Dependency = Get-Dependency \\Path\To\complex.depend.ps1
-$Dependency[2] | Select *
+$Dependency = Get-Dependency \\Path\To\complex.depend.psd1
+$Dependency[2] | Select-Object *
 ```
 
 ```
@@ -152,51 +123,35 @@ PostScripts    :
 Raw            : {Version, Name, Tags, DependsOn...}
 ```
 
-Note that we replace certain strings in Target and Source fields:
-
-* $PWD (or .) refer to the current path
-* $ENV:USERPROFILE, $ENV:TEMP, $ENV:ProgramData, $ENV:APPDATA
-* Variables need to be in single quotes or the $ needs to be escaped.  We replace the raw strings with the values for you. This will not work: Target = "$PWD\dependencies".  This will: Target = '$PWD\dependencies'
-* If you call Invoke-PSDepend -Target $Something, we override any value for target
-* Thanks to Mike Walker for the idea!
+The following strings are expanded in `Target` and `Source` fields: `$PWD` (or `.`), `$ENV:USERPROFILE`, `$ENV:TEMP`, `$ENV:ProgramData`, `$ENV:APPDATA`. Use single quotes or escape the `$` to prevent PowerShell from expanding them before PSDepend can: `Target = '$PWD\dependencies'`.
 
 ### Repository Credentials
 
-If you are using a PowerShell module repository that requires authentication then add those to your dependency. When working with credentials there are two parts we need to consider:
-
-* Credential property of our dependency.
-* Credentials parameter for Invoke-PSDepend.
+For private repositories that require authentication, set a `Credential` key in the dependency and pass a matching `PSCredential` object to `Invoke-PSDepend`:
 
 ```powershell
 @{
-    psdeploy = 'latest'
-
     buildhelpers_0_0_20 = @{
         Name = 'buildhelpers'
         DependencyType = 'PSGalleryModule'
         Parameters = @{
-            Repository = 'PSGallery'
-            SkipPublisherCheck = $true
+            Repository = 'MyPrivateGallery'
         }
         Version = '0.0.20'
-        Credential = 'must_match'
+        Credential = 'my_gallery'
     }
 }
 ```
 
-Now create a `PSCredential` object with the credentials to access the repository and run it:
-
 ```powershell
-Invoke-PSDepend -Path C:\requirements.psd1 -Credentials @{ 'must_match' = $creds }
+Invoke-PSDepend -Path C:\requirements.psd1 -Credentials @{ 'my_gallery' = $creds }
 ```
 
-Make sure whatever you use as `must_match` is the same in the dependency as it is in the hashtable you pass to the Credentials parameter.
+The credential key must match between the dependency definition and the hashtable passed to `-Credentials`.
 
-## Exploring and Getting Help
+## Getting Help
 
-Each DependencyType - PSGalleryModule, FileDownload, Task, etc. - might treat these standard properties differently, and may include their own Parameters.  For example, in the BuildHelpers node above, we specified a Repository and SkipPublisherCheck parameters.
-
-How do we find out what these mean?  First things first, let's look at what DependencyTypes we have available:
+Each dependency type may handle standard properties differently and expose its own parameters. Use `Get-PSDependType` to see what is available:
 
 ```powershell
 Get-PSDependType
@@ -211,35 +166,15 @@ Noop            Display parameters that a depends script would receive...   C:\.
 FileDownload    Download a file                                             C:\...\PSDepend\PSDepen...
 ```
 
-Now that we know what types are available, we can read the comment-based help.  Hopefully the author took their time to write this:
+Read the comment-based help for any dependency type:
 
-```PowerShell
+```powershell
 Get-PSDependType -DependencyType PSGalleryModule -ShowHelp
 ```
 
-```
-...
-DESCRIPTION
-    Installs a module from a PowerShell repository like the PowerShell Gallery.
+Additional help topics:
 
-    Relevant Dependency metadata:
-        Name: The name for this module
-        Version: Used to identify existing installs meeting this criteria, and as RequiredVersion for installation.  Defaults to 'latest'
-        Target: Used as 'Scope' for Install-Module.  If this is a path, we use Save-Module with this path.  Defaults to 'AllUsers'
-
-PARAMETERS
-...
-    -Repository <String>
-        PSRepository to download from.  Defaults to PSGallery
-    -SkipPublisherCheck <Switch>
-        Bypass the catalog signing check.  Defaults to $false
-```
-
-In this example, we see how PSGalleryModule treats the Name, Version, and Target in a depend.psd1, and we see Parameter's specific to this DependencyType, 'Repository' and 'SkipPublisherCheck'
-
-Finally, we have a few about topics, and individual commands have built in help:
-
-```
+```powershell
 Get-Help about_PSDepend
 Get-Help about_PSDepend_Definitions
 Get-Help Get-Dependency -Full
@@ -247,122 +182,28 @@ Get-Help Get-Dependency -Full
 
 ## Extending PSDepend
 
-PSDepend is extensible.  To create a new dependency type:
+PSDepend is extensible. To add a new dependency type, create a script in the [PSDependScripts folder](https://github.com/PowerShellOrg/PSDepend/tree/master/PSDepend/PSDependScripts) and register it in [PSDependMap.psd1](https://github.com/PowerShellOrg/PSDepend/blob/master/PSDepend/PSDependMap.psd1).
 
-* Pick a name.  We'll use `Nothing` as an example
-* Create `DependencyType.ps1` (substituting in your name, e.g. `Nothing.ps1`) in the [PSDependScripts folder](https://github.com/RamblingCookieMonster/PSDepend/tree/master/PSDepend/PSDependScripts)
-* Your `DependencyType.ps1` (`Nothing.ps1` in this example) should...
-  * Have comment based help
-  * Include details on how you use Dependency metadata.  For example, in [Git.ps1](https://github.com/RamblingCookieMonster/PSDepend/blob/master/PSDepend/PSDependScripts/Git.ps1), `Version` is used in git checkout
-  * Include a PSDependAction parameter that takes `Install`, `Test`, `Import`, or a subset of these.  [Example parameter declaration](https://github.com/RamblingCookieMonster/PSDepend/blob/master/PSDepend/PSDependScripts/PSGalleryModule.ps1#L40)
-  * Depending on which PSDependAction is specified by the user, your script should `install`, `test` (return true or false depending on whether the dependency exists - sometimes this is impossible to check), and `import` (import the dependency - if appropriate, this might import a module or dot source code, for example)
-* Add your new dependency type to [PSDependMap.psd1](https://github.com/RamblingCookieMonster/PSDepend/blob/master/PSDepend/PSDependMap.psd1)
+Your script must:
 
-So!  In our example, we would create `PSDepend\PSDependScripts\Nothing.ps1`, with the following code:
+- Include comment-based help describing how it uses `Dependency` metadata
+- Accept a `PSDependAction` parameter with values `Install`, `Test`, and/or `Import`
+- Implement the expected behavior for each action (`Install` installs, `Test` returns a boolean, `Import` loads the dependency)
 
-```powershell
-<#
-    .SYNOPSIS
-        Example Dependency
+See [Git.ps1](https://github.com/PowerShellOrg/PSDepend/blob/master/PSDepend/PSDependScripts/Git.ps1) and [PSGalleryModule.ps1](https://github.com/PowerShellOrg/PSDepend/blob/master/PSDepend/PSDependScripts/PSGalleryModule.ps1) for reference implementations.
 
-    .DESCRIPTION
-        Example Dependency
+## Examples
 
-        Relevant Dependency metadata:
-            Version: Used for nonsense output
+- [Creating a virtual environment](/Examples/VirtualEnvironment.md)
+- [Handling module dependencies](/Examples/ModuleDependencies.md)
+- [How Do I...](/Examples/HowDoI.md)
 
-    .PARAMETER Dependency
-        Dependency to process
+## Contributing
 
-    .PARAMETER StringParameter
-        An example parameter that does nothing
+Contributions are welcome. Please read the [PowerShellOrg contributing guide](https://github.com/PowerShellOrg/.github/blob/main/.github/CONTRIBUTING.md) before opening a pull request.
 
-    .PARAMETER PSDependAction
-        Test, Install, or Import the dependency.  Defaults to Install
+## Acknowledgements
 
-        Test: Return true or false on whether the dependency is in place
-        Install: Install the dependency
-        Import: Import the dependency
-#>
-[cmdletbinding()]
-param (
-    [PSTypeName('PSDepend.Dependency')]
-    [psobject[]]$Dependency,
+PSDepend was originally created by [Warren Frame (RamblingCookieMonster)](https://github.com/RamblingCookieMonster) and is now maintained by the [PowerShellOrg](https://github.com/PowerShellOrg) organization.
 
-    [ValidateSet('Test', 'Install', 'Import')]
-    [string[]]$PSDependAction = @('Install'),
-
-    [string]$StringParameter
-)
-
-$Output = [PSCustomobject]@{
-    DependencyName = $Dependency.DependencyName
-    Status = "Invoking $PSDependAction action"
-    BoundParameters = $PSBoundParameters.Keys
-    Message = "Version [$Version]"
-}
-
-# Notice that we end the script if we're testing.
-if( $PSDependAction -Contains 'Test' )
-{
-    Write-Verbose $Output
-    return $true
-}
-
-$Output
-```
-
-Finally, we'll add an entry to `PSDependMap.psd1`:
-
-```powershell
-    Nothing = @{
-        Script= 'Nothing.ps1'
-        Description = 'Example dependency'
-    }
-```
-
-Lastly, we'll define a requirements.psd1 using this dependency:
-
-```powershell
-@{
-    ExampleDependency = @{
-        DependencyType = 'Nothing'
-        Version = 1
-        Parameters = @{
-            StringParameter = 'A thing'
-        }
-    }
-}
-```
-
-Finally, run it!
-
-```powershell
-Invoke-PSDepend -Path C:\requirements.psd1 -Test -Quiet
-```
-
-`True`
-
-```powershell
-Invoke-PSDepend -Path C:\requirements.psd1
-```
-
-```
-DependencyName    Status                  BoundParameters                               Message
---------------    ------                  ---------------                               -------
-ExampleDependency Invoking Install action {StringParameter, PSDependAction, Dependency} Version [1]
-```
-
-```powershell
-Invoke-PSDepend -Path C:\requirements.psd1 -Import
-```
-
-```
-DependencyName    Status                 BoundParameters                               Message
---------------    ------                 ---------------                               -------
-ExampleDependency Invoking Import action {StringParameter, PSDependAction, Dependency} Version [1]
-```
-
-## Notes
-
-Major props to Michael Willis for the idea - check out his [PSRequire](https://github.com/Xainey/PSRequire), a similar but more feature-full solution.
+The concept was inspired by Michael Willis's [PSRequire](https://github.com/Xainey/PSRequire).


### PR DESCRIPTION
## What this changes

Updates the README and Examples to reflect the project's transfer to PowerShellOrg. Removes stale references to the original author's tooling (Appveyor, PS 3/4 bootstrap, personal repo links), adds a GitHub Actions CI workflow mirroring Plaster's structure, and rewrites the documentation in a consistent, professional tone.

## Why

Closes #144

## Type of change

- [X] Chore / refactor / documentation (no behavior change)

## Checklist

- [ ] Pester tests added or updated to cover the change
- [ ] `Invoke-psake Analyze` passes locally with no new warnings
- [ ] `Invoke-psake Test` passes locally on at least one platform
- [ ] `CHANGELOG.md` updated (required for any user-facing change)
- [X] Documentation updated if behavior changed

## Additional notes

- FUNDING.yml was removed as it pointed to the original author; can re-add if GitHub Sponsors is
  configured
- The publish-test-results CI job will have nothing to publish until psake.ps1 is updated to write results to a stable path
- ci.yml was borrowed from Plaster
- CHANGELOG.md doesn't exist yet so it was not updated