### PR TITLE
update cicd workflow actions to the newest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Bootstrap
         shell: pwsh
         run: ./build.ps1 -Bootstrap -Task Init
@@ -37,7 +37,7 @@ jobs:
         run: ./build.ps1 -Task Test
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testResults-${{ matrix.os }}
           path: ./Tests/out/testResults.xml
@@ -48,7 +48,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Bootstrap
         shell: powershell
         run: ./build.ps1 -Bootstrap -Task Init
@@ -57,7 +57,7 @@ jobs:
         run: ./build.ps1 -Task Test
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: testResults-ps51
           path: ./Tests/out/testResults.xml
@@ -72,7 +72,7 @@ jobs:
       pull-requests: write
     if: ${{ !cancelled() }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
       - uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## What this changes

This change updates the current github actions to run on the newest versions.
Bumping node (for some v16 and others v20) to all run on Node v24

## Why

This ensures we do not suddenly have to make changes in the future as the releases this currently runs on is the next runner ups for deprecation.
Also always good to keep things you depend on up to date and ensure they run on the new actions

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that corrects incorrect behavior)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Chore / refactor / documentation (no behavior change)

## Checklist

- [ ] Pester tests added or updated to cover the change
- [ ] `Invoke-psake Analyze` passes locally with no new warnings
- [ ] `Invoke-psake Test` passes locally on at least one platform
- [ ] `CHANGELOG.md` updated (required for any user-facing change)
- [ ] Documentation updated if behavior changed

## Additional notes

To view changes / release notes you can find them on below links:
(Actions checkout)
https://github.com/actions/checkout#checkout-v6
(upload-artifact)
https://github.com/actions/upload-artifact/releases
(download-artifact)
https://github.com/actions/download-artifact/releases