### PR TITLE
Fix version comparison logic for 'latest' upgrades in PSGalleryModule and Package scripts

### DIFF
--- a/PSDepend/PSDependScripts/PSGalleryModule.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryModule.ps1
@@ -251,16 +251,22 @@ if($Existing) {
     }
 
     $GalleryVersion = Find-Module @FindModuleParams | Measure-Object -Property Version -Maximum | Select-Object -ExpandProperty Maximum
-    [System.Version]$parsedVersion = $null
-    [System.Management.Automation.SemanticVersion]$parsedSemanticVersion = $null
-    [System.Management.Automation.SemanticVersion]$parsedTempSemanticVersion = $null
+    [System.Version]$parsedExistingVersion = $null
+    [System.Version]$parsedGalleryVersion = $null
+    [System.Management.Automation.SemanticVersion]$parsedExistingSemanticVersion = $null
+    [System.Management.Automation.SemanticVersion]$parsedGallerySemanticVersion = $null
     $isGalleryVersionLessEquals = if (
-        [System.Management.Automation.SemanticVersion]::TryParse($ExistingVersion, [ref]$parsedSemanticVersion) -and
-        [System.Management.Automation.SemanticVersion]::TryParse($GalleryVersion, [ref]$parsedTempSemanticVersion)
+        [System.Management.Automation.SemanticVersion]::TryParse([string]$ExistingVersion, [ref]$parsedExistingSemanticVersion) -and
+        [System.Management.Automation.SemanticVersion]::TryParse([string]$GalleryVersion, [ref]$parsedGallerySemanticVersion)
     ) {
-        $GalleryVersion -le $parsedSemanticVersion
-    } elseif ([System.Version]::TryParse($ExistingVersion, [ref]$parsedVersion)) {
-        $GalleryVersion -le $parsedVersion
+        $parsedGallerySemanticVersion -le $parsedExistingSemanticVersion
+    } elseif (
+        [System.Version]::TryParse([string]$ExistingVersion, [ref]$parsedExistingVersion) -and
+        [System.Version]::TryParse([string]$GalleryVersion, [ref]$parsedGalleryVersion)
+    ) {
+        $parsedGalleryVersion -le $parsedExistingVersion
+    } else {
+        $false
     }
 
     # latest, and we have latest

--- a/PSDepend/PSDependScripts/Package.ps1
+++ b/PSDepend/PSDependScripts/Package.ps1
@@ -184,10 +184,29 @@ if($Existing)
         return $null
     }
     
+    $SourceVersion = (& $GetSourceVersion)
+    [System.Version]$parsedExistingVersion = $null
+    [System.Version]$parsedSourceVersion = $null
+    [System.Management.Automation.SemanticVersion]$parsedExistingSemanticVersion = $null
+    [System.Management.Automation.SemanticVersion]$parsedSourceSemanticVersion = $null
+    $isSourceVersionLessEquals = if (
+        [System.Management.Automation.SemanticVersion]::TryParse([string]$ExistingVersion, [ref]$parsedExistingSemanticVersion) -and
+        [System.Management.Automation.SemanticVersion]::TryParse([string]$SourceVersion, [ref]$parsedSourceSemanticVersion)
+    ) {
+        $parsedSourceSemanticVersion -le $parsedExistingSemanticVersion
+    } elseif (
+        [System.Version]::TryParse([string]$ExistingVersion, [ref]$parsedExistingVersion) -and
+        [System.Version]::TryParse([string]$SourceVersion, [ref]$parsedSourceVersion)
+    ) {
+        $parsedSourceVersion -le $parsedExistingVersion
+    } else {
+        $false
+    }
+
     # latest, and we have latest
     if( $Version -and
         ($Version -eq 'latest' -or $Version -like '') -and
-        ($SourceVersion = (& $GetSourceVersion)) -le $ExistingVersion
+        $isSourceVersionLessEquals
     )
     {
         Write-Verbose "You have the latest version of [$Name], with installed version [$ExistingVersion] and package source version [$SourceVersion]"

--- a/Tests/PSGalleryModule.Type.Tests.ps1
+++ b/Tests/PSGalleryModule.Type.Tests.ps1
@@ -119,6 +119,21 @@ Describe 'PSGalleryModule script' {
         }
     }
 
+    Context 'Latest version comparison' {
+        It 'Installs when installed version 2.8.0 is behind gallery version 2.10.0' {
+            InModuleScope PSDepend {
+                Mock Get-Module { [PSCustomObject]@{ Name = 'TestModule'; Version = [version]'2.8.0' } } -ParameterFilter { $ListAvailable }
+                Mock Find-Module { [PSCustomObject]@{ Name = 'TestModule'; Version = [version]'2.10.0' } }
+            }
+            $dep = New-PSDependFixture -DependencyName 'TestModule' -Version 'latest'
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep
+            }
+
+            Should -Invoke -CommandName Install-Module -ModuleName PSDepend -Times 1
+        }
+    }
+
     Context 'Target as path uses Save-Module instead of Install-Module' {
         It 'Calls Save-Module with the target path' {
             $savePath = (New-Item 'TestDrive:/save' -ItemType Directory -Force).FullName

--- a/Tests/Package.Type.Tests.ps1
+++ b/Tests/Package.Type.Tests.ps1
@@ -63,4 +63,19 @@ Describe 'Package script' {
             }
         } | Should -Throw -ExpectedMessage '*Nuget*Target*'
     }
+
+    It 'Installs when installed version 2.8.0 is behind source version 2.10.0 and latest is requested' {
+        $targetDir = (New-Item 'TestDrive:/pkg3' -ItemType Directory -Force).FullName
+        InModuleScope PSDepend {
+            Mock Get-Package  { [PSCustomObject]@{ Name = 'jquery'; Version = [version]'2.8.0' } }
+            Mock Find-Package { [PSCustomObject]@{ Name = 'jquery'; Version = [version]'2.10.0' } }
+        }
+
+        $dep = New-PSDependFixture -DependencyName 'jquery' -DependencyType 'Package' -Target $targetDir -Source 'nuget.org' -Version 'latest'
+        InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+            & $ScriptPath -Dependency $Dep
+        }
+
+        Should -Invoke -CommandName Install-Package -ModuleName PSDepend -Times 1
+    }
 }


### PR DESCRIPTION
## Root Cause

PSDepend was failing to upgrade modules/packages when requesting `'latest'` if a newer minor version was available. For example, machines with version 2.8.0 would not upgrade to 2.10.0, reporting:

```
You have the latest version of [module-name], with installed version [2.8.0] and PSGallery version [2.10.0]
```

The issue was **string-based version comparison** instead of typed version comparison. When comparing as strings:
- `"2.10.0" -le "2.8.0"` evaluates to `$true` (because "1" < "8" lexically)

This caused the logic to incorrectly conclude that 2.10.0 was not newer than 2.8.0.

## Solution

Both PSGalleryModule.ps1 and Package.ps1 now:

1. Attempt to parse versions as `[System.Management.Automation.SemanticVersion]` objects first
2. Fall back to `[System.Version]` if SemanticVersion parsing fails  
3. Compare the **typed objects** instead of strings
4. Return `$false` if neither parsing method succeeds

## Testing

Added regression tests to catch this scenario:
- **PSGalleryModule.Type.Tests.ps1**: Verifies 2.8.0 → 2.10.0 upgrade with `latest`
- **Package.Type.Tests.ps1**: Same scenario for Package dependencies

Fixes #139
Fixes #153