### PR TITLE
refactor(tests): 🔧 Update test setup to use build script

### DIFF
--- a/Tests/Chocolatey.Type.Tests.ps1
+++ b/Tests/Chocolatey.Type.Tests.ps1
@@ -7,7 +7,7 @@ BeforeDiscovery {
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Command.Type.Tests.ps1
+++ b/Tests/Command.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/DotnetSdk.Type.Tests.ps1
+++ b/Tests/DotnetSdk.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/FileDownload.Type.Tests.ps1
+++ b/Tests/FileDownload.Type.Tests.ps1
@@ -7,7 +7,7 @@ BeforeDiscovery {
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/FileSystem.Type.Tests.ps1
+++ b/Tests/FileSystem.Type.Tests.ps1
@@ -7,7 +7,7 @@ BeforeDiscovery {
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Git.Type.Tests.ps1
+++ b/Tests/Git.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/GitHub.Type.Tests.ps1
+++ b/Tests/GitHub.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Noop.Type.Tests.ps1
+++ b/Tests/Noop.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Npm.Type.Tests.ps1
+++ b/Tests/Npm.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Nuget.Type.Tests.ps1
+++ b/Tests/Nuget.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/PSGalleryModule.Type.Tests.ps1
+++ b/Tests/PSGalleryModule.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/PSGalleryNuget.Type.Tests.ps1
+++ b/Tests/PSGalleryNuget.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Package.Type.Tests.ps1
+++ b/Tests/Package.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force

--- a/Tests/Task.Type.Tests.ps1
+++ b/Tests/Task.Type.Tests.ps1
@@ -2,7 +2,7 @@
 
 BeforeAll {
     if (-not $env:BHProjectPath) {
-        Set-BuildEnvironment -Path "$PSScriptRoot/.." -Force
+        & "$PSScriptRoot\..\build.ps1" -Task 'Build'
     }
     Remove-Module $env:BHProjectName -ErrorAction SilentlyContinue
     Import-Module (Join-Path $env:BHProjectPath $env:BHProjectName) -Force


### PR DESCRIPTION
* Replaced `Set-BuildEnvironment` with a call to the build script in multiple test files.
* This change standardizes the test environment setup across all test cases.
* Allows easier testing with the Testing VS Code tool.

## What this changes
Ensures that a build is run before a Pester test run. This help when invoking directly with Pester or via the VS Code Test tool.

## Why

<!-- The motivation. Link to the issue this fixes or the discussion that prompted it. -->

Closes #

## Type of change

- [ ] Bug fix (non-breaking change that corrects incorrect behavior)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [x] Chore / refactor / documentation (no behavior change)

## Checklist

- [x] Pester tests added or updated to cover the change
- [ ] `Invoke-psake Analyze` passes locally with no new warnings
- [ ] `Invoke-psake Test` passes locally on at least one platform
- [ ] `CHANGELOG.md` updated (required for any user-facing change)
- [ ] Documentation updated if behavior changed

## Additional notes

<!-- Anything reviewers should know: edge cases, known limitations, follow-up work, testing instructions. -->
