### PR TITLE
fix(Get-Dependency): correct operator precedence bug when DependencyType set in PSDependOptions (#131)

### DIFF
--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -258,8 +258,8 @@ function Get-Dependency {
             # It doesn't look like a git repo, and simple syntax: PSGalleryModule
             elseif( $DependencyHash -is [string] -and
                 $Dependency -notmatch '/' -and
-                -not $DependencyType -or
-                $DependencyType -eq 'PSGalleryModule') {
+                (-not $DependencyType -or
+                $DependencyType -eq 'PSGalleryModule')) {
                 [PSCustomObject]@{
                     PSTypeName = 'PSDepend.Dependency'
                     DependencyFile = $DependencyFile
@@ -284,8 +284,8 @@ function Get-Dependency {
             elseif($DependencyHash -is [string] -and
                 $Dependency -match '/' -and
                 $Dependency.split('/').count -eq 2 -and
-                -not $DependencyType -or
-                $DependencyType -eq 'GitHub') {
+                (-not $DependencyType -or
+                $DependencyType -eq 'GitHub')) {
                 [PSCustomObject]@{
                     PSTypeName = 'PSDepend.Dependency'
                     DependencyFile = $DependencyFile
@@ -308,8 +308,8 @@ function Get-Dependency {
             # It looks like a git repo, and simple syntax: Git
             elseif($DependencyHash -is [string] -and
                 $Dependency -match '/' -and
-                -not $DependencyType -or
-                $DependencyType -eq 'Git' ) {
+                (-not $DependencyType -or
+                $DependencyType -eq 'Git')) {
                 [PSCustomObject]@{
                     PSTypeName = 'PSDepend.Dependency'
                     DependencyFile = $DependencyFile


### PR DESCRIPTION
## Summary

- Fixes #131 — when `DependencyType` is set globally via `PSDependOptions`, advanced hashtable dependencies were incorrectly parsed: the entire `@{Version=...; Parameters=...}` hashtable was assigned to `Version` instead of being unpacked.
- Root cause: PowerShell evaluates `-and` before `-or`, so the three `elseif` branches in `Parse-Dependency` had unintended grouping — `(-not $DependencyType) OR ($DependencyType -eq 'X')` was effectively `(... -and -not $DependencyType) OR ($DependencyType -eq 'X')`, short-circuiting to `$true` for every dependency when a type was set globally.
- Fix: add parentheses around the type sub-expression in all three branches (PSGalleryModule, GitHub, Git).

## Test plan

- [x] Reproduce with the issue's example: `Get-Dependency -InputObject $dep` where `PSDependOptions.DependencyType = 'PSGalleryModule'` and a dependency uses hashtable syntax — `Version` should now be `'latest'` (String), not `{Version, Parameters}` (Hashtable).
- [x] `Invoke-Pester .\Tests\` — 353 tests, 0 failures.
- [ ] Confirm simple-string syntax (`PsDepend = 'latest'`) still works without `DependencyType` in `PSDependOptions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)