### PR TITLE
fix: bootstrap NuGet lazily only when a Nuget/PSGalleryNuget dep is used

### DIFF
--- a/PSDepend/PSDepend.psm1
+++ b/PSDepend/PSDepend.psm1
@@ -16,7 +16,7 @@
         }
     }
 
-#Get nuget dependecy file if we don't have it
+#Read PSDepend.Config path variables
     Get-Content $ModuleRoot\PSDepend.Config |
         Where-Object {$_ -and $_ -notmatch "^\s*#"} |
         Foreach-Object {
@@ -27,8 +27,5 @@
             $Value = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Value)
             Set-Variable -Name $Name -Value $Value
         }
-    if(Test-PlatformSupport -Support 'windows','core') {
-        BootStrap-Nuget -NugetPath $NuGetPath
-    }
 
 Export-ModuleMember -Function $Public.Basename

--- a/PSDepend/PSDependScripts/Nuget.ps1
+++ b/PSDepend/PSDependScripts/Nuget.ps1
@@ -109,7 +109,7 @@ param(
 
 if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
 {
-    if(Test-PlatformSupport -Support 'windows','core')
+    if(Test-PlatformSupport -Type 'Nuget' -Support 'windows','core')
     {
         BootStrap-Nuget -NugetPath $NuGetPath
     }

--- a/PSDepend/PSDependScripts/Nuget.ps1
+++ b/PSDepend/PSDependScripts/Nuget.ps1
@@ -109,7 +109,15 @@ param(
 
 if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
 {
-    Write-Error "Nuget requires Nuget.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's NugetPath.  Skipping [$DependencyName]"
+    if(Test-PlatformSupport -Support 'windows','core')
+    {
+        BootStrap-Nuget -NugetPath $NuGetPath
+    }
+    if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
+    {
+        Write-Error "Nuget requires Nuget.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's NugetPath.  Skipping [$DependencyName]"
+        return
+    }
 }
 
 Write-Verbose -Message "Getting dependency [$DependencyName] from Nuget source [$Source]"

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -97,7 +97,15 @@ param(
 
 if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
 {
-    Write-Error "PSGalleryNuget requires Nuget.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's NugetPath.  Skipping [$DependencyName]"
+    if(Test-PlatformSupport -Support 'windows','core')
+    {
+        BootStrap-Nuget -NugetPath $NuGetPath
+    }
+    if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
+    {
+        Write-Error "PSGalleryNuget requires Nuget.exe.  Ensure this is in your path, or explicitly specified in $ModuleRoot\PSDepend.Config's NugetPath.  Skipping [$DependencyName]"
+        return
+    }
 }
 
 Write-Verbose -Message "Getting dependency [$name] from Nuget source [$Source]"

--- a/PSDepend/PSDependScripts/PSGalleryNuget.ps1
+++ b/PSDepend/PSDependScripts/PSGalleryNuget.ps1
@@ -97,7 +97,7 @@ param(
 
 if(-not (Get-Command Nuget -ErrorAction SilentlyContinue))
 {
-    if(Test-PlatformSupport -Support 'windows','core')
+    if(Test-PlatformSupport -Type 'PSGalleryNuget' -Support 'windows','core')
     {
         BootStrap-Nuget -NugetPath $NuGetPath
     }

--- a/Tests/Nuget.Type.Tests.ps1
+++ b/Tests/Nuget.Type.Tests.ps1
@@ -52,4 +52,44 @@ Describe 'Nuget script' {
             $Arguments -contains '-version' -and $Arguments -contains '12.0.2'
         }
     }
+
+    Context 'NuGet bootstrap' {
+        BeforeAll {
+            InModuleScope PSDepend {
+                Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Nuget' }
+                Mock BootStrap-Nuget { }
+                Mock Test-PlatformSupport { $true }
+            }
+        }
+
+        It 'Calls BootStrap-Nuget when nuget.exe is missing on a supported platform' {
+            $targetDir = (New-Item 'TestDrive:/nuget-bootstrap' -ItemType Directory -Force).FullName
+            $dep = New-PSDependFixture -DependencyName 'Newtonsoft.Json' -DependencyType 'Nuget' -Target $targetDir
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -ErrorAction SilentlyContinue
+            }
+            Should -Invoke -CommandName BootStrap-Nuget -ModuleName PSDepend -Times 1
+        }
+
+        It 'Does not invoke nuget install when nuget.exe is still missing after bootstrap' {
+            $targetDir = (New-Item 'TestDrive:/nuget-bootstrap-fail' -ItemType Directory -Force).FullName
+            $dep = New-PSDependFixture -DependencyName 'Newtonsoft.Json' -DependencyType 'Nuget' -Target $targetDir
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -ErrorAction SilentlyContinue
+            }
+            Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0
+        }
+
+        It 'Does not call BootStrap-Nuget on an unsupported platform' {
+            InModuleScope PSDepend {
+                Mock Test-PlatformSupport { $false }
+            }
+            $targetDir = (New-Item 'TestDrive:/nuget-bootstrap-noplatform' -ItemType Directory -Force).FullName
+            $dep = New-PSDependFixture -DependencyName 'Newtonsoft.Json' -DependencyType 'Nuget' -Target $targetDir
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -ErrorAction SilentlyContinue
+            }
+            Should -Invoke -CommandName BootStrap-Nuget -ModuleName PSDepend -Times 0
+        }
+    }
 }

--- a/Tests/PSGalleryNuget.Type.Tests.ps1
+++ b/Tests/PSGalleryNuget.Type.Tests.ps1
@@ -51,4 +51,44 @@ Describe 'PSGalleryNuget script' {
         }
         Should -Invoke -CommandName Import-PSDependModule -ModuleName PSDepend -Times 1
     }
+
+    Context 'NuGet bootstrap' {
+        BeforeAll {
+            InModuleScope PSDepend {
+                Mock Get-Command { $null } -ParameterFilter { $Name -eq 'Nuget' }
+                Mock BootStrap-Nuget { }
+                Mock Test-PlatformSupport { $true }
+            }
+        }
+
+        It 'Calls BootStrap-Nuget when nuget.exe is missing on a supported platform' {
+            $targetDir = (New-Item 'TestDrive:/psgnuget-bootstrap' -ItemType Directory -Force).FullName
+            $dep = New-PSDependFixture -DependencyName 'PSDeploy' -DependencyType 'PSGalleryNuget' -Target $targetDir
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -ErrorAction SilentlyContinue
+            }
+            Should -Invoke -CommandName BootStrap-Nuget -ModuleName PSDepend -Times 1
+        }
+
+        It 'Does not invoke nuget install when nuget.exe is still missing after bootstrap' {
+            $targetDir = (New-Item 'TestDrive:/psgnuget-bootstrap-fail' -ItemType Directory -Force).FullName
+            $dep = New-PSDependFixture -DependencyName 'PSDeploy' -DependencyType 'PSGalleryNuget' -Target $targetDir
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -ErrorAction SilentlyContinue
+            }
+            Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0
+        }
+
+        It 'Does not call BootStrap-Nuget on an unsupported platform' {
+            InModuleScope PSDepend {
+                Mock Test-PlatformSupport { $false }
+            }
+            $targetDir = (New-Item 'TestDrive:/psgnuget-bootstrap-noplatform' -ItemType Directory -Force).FullName
+            $dep = New-PSDependFixture -DependencyName 'PSDeploy' -DependencyType 'PSGalleryNuget' -Target $targetDir
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -ErrorAction SilentlyContinue
+            }
+            Should -Invoke -CommandName BootStrap-Nuget -ModuleName PSDepend -Times 0
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #117.

PSDepend was unconditionally downloading `nuget.exe` at module load time via `BootStrap-Nuget` in `PSDepend.psm1`, even when no `Nuget` or `PSGalleryNuget` dependencies were declared. Users relying purely on `PSGalleryModule` (or any other type) had no way to suppress this network call.

- Remove the eager `BootStrap-Nuget` call from `PSDepend.psm1`
- Move it into `Nuget.ps1` and `PSGalleryNuget.ps1` so it only runs when one of those dependency types is actually invoked
- Wrap the call in `Test-PlatformSupport` (matching the original guard) so bootstrap is skipped on platforms where `nuget.exe` isn't applicable
- Add a missing `return` after `Write-Error` in both scripts — previously execution would continue into the `nuget install` invocation even after the error

## Test plan

- [x] `Nuget.Type.Tests.ps1` — new `NuGet bootstrap` context: verifies `BootStrap-Nuget` is called when `nuget.exe` is missing on a supported platform, not called on unsupported platforms, and that `Invoke-ExternalCommand` is never reached when nuget remains unavailable after bootstrap
- [x] `PSGalleryNuget.Type.Tests.ps1` — same three cases for the `PSGalleryNuget` script
- [x] All 12 tests pass (`Passed: 12 | Failed: 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)