### PR TITLE
fix(tests): mock Install-Dotnet in DotnetSdk install test

### DIFF
--- a/Tests/PSModuleGallery.Type.Tests.ps1
+++ b/Tests/PSModuleGallery.Type.Tests.ps1
@@ -1176,10 +1176,13 @@ Describe "PSModuleGallery Type" -Tag 'Integration' {
             }
 
             It 'Installs the .NET Core SDK to the specified directory' {
-                Mock Test-Dotnet { return $false } -ModuleName PSDepend
+                Mock Test-Dotnet    { return $false } -ModuleName PSDepend
+                Mock Install-Dotnet {               } -ModuleName PSDepend
 
                 Invoke-PSDepend @Verbose -Path "$TestDepends\dotnetsdk.complex.depend.psd1" -Force
-                Test-Path $script:SavePath | Should -BeTrue
+                Should -Invoke Install-Dotnet -Times 1 -Exactly -ModuleName PSDepend -ParameterFilter {
+                    $InstallDir -eq $script:SavePath
+                }
             }
 
             It 'Does nothing if the .NET Core SDK is found' {


### PR DESCRIPTION
## Summary

- The `DotnetSdk Type > Installs Dependency > Installs the .NET Core SDK to the specified directory` test was an accidental integration test — it mocked `Test-Dotnet` but left `Install-Dotnet` unmocked, causing it to invoke the real dotnet-install script on CI runners.
- The real installer requires network access and writes to a relative `.dotnet` path that doesn't exist on runners, so `Test-Path '.dotnet'` always returned `$false`.
- Fix: add a `Mock Install-Dotnet` and replace the filesystem assertion with `Should -Invoke Install-Dotnet -Times 1 -Exactly` with a `$InstallDir` parameter filter.

## Test plan

- [x] `Tests/PSModuleGallery.Type.Tests.ps1` — 89 tests, all pass locally
- [x] The fixed test now asserts behavior (Install-Dotnet is called with the right directory) rather than side-effects (a real directory was created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)