### PR TITLE
Bump version to 0.4.0-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-alpha] - 2026-05-21
+
 ### Added
 
 - `PSResourceGet` dependency type providing first-class support for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0-alpha] - 2026-05-21
+## [0.4.0-alpha] - 2026-05-26
 
 ### Added
 

--- a/PSDepend/PSDepend.psd1
+++ b/PSDepend/PSDepend.psd1
@@ -4,7 +4,7 @@
     RootModule = 'PSDepend.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.3.0'
+    ModuleVersion = '0.4.0'
 
     # ID used to uniquely identify this module
     GUID = '63ea9e2a-320d-43ff-a11a-4930ca03cce6'
@@ -109,7 +109,7 @@
             ReleaseNotes = 'https://github.com/PowerShellOrg/PSDepend/blob/main/CHANGELOG.md'
 
             # Prerelease string (e.g. 'beta1', 'rc2'). Empty string = stable release.
-            Prerelease   = ''
+            Prerelease   = 'alpha'
 
         } # End of PSData hashtable
 


### PR DESCRIPTION
## Summary

- Sets `ModuleVersion` to `0.4.0` in `PSDepend.psd1`
- Sets `Prerelease` to `'alpha'` in `PSDepend.psd1`, making the published identifier `0.4.0-alpha`
- Promotes the `[Unreleased]` section in `CHANGELOG.md` to `[0.4.0-alpha] - 2026-05-21`

## Test plan

- [ ] Verify `(Import-Module PSDepend -PassThru).Version` returns `0.4.0`
- [ ] Verify `(Import-Module PSDepend -PassThru).PrivateData.PSData.Prerelease` returns `alpha`
- [ ] Confirm CHANGELOG heading reads `[0.4.0-alpha] - 2026-05-21`

https://claude.ai/code/session_0124xRfAyqpJQoLoKUycDism

---
_Generated by [Claude Code](https://claude.ai/code/session_0124xRfAyqpJQoLoKUycDism)_