### PR TITLE
refactor(workflow): replace isPrerelease with force input

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,16 @@ on:
         required: false
         type: boolean
         default: false
+      create_release:
+        description: "If false, skip creating the GitHub release and tag."
+        required: false
+        type: boolean
+        default: true
+      publish:
+        description: "If false, skip publishing to PowerShell Gallery."
+        required: false
+        type: boolean
+        default: true
 permissions:
   contents: write
 jobs:
@@ -29,4 +39,6 @@ jobs:
       version: ${{ inputs.version || '' }}
       force: ${{ inputs.force || false }}
       dry_run: ${{ inputs.dry_run || false }}
+      create_release: ${{ inputs.create_release != false }}
+      publish: ${{ inputs.publish != false }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,8 +9,8 @@ on:
         description: "The version to publish. Leave empty to use the version in the module manifest."
         required: false
         type: string
-      isPrerelease:
-        description: "Is this a prerelease version?"
+      force:
+        description: "If true, bypass the PSGallery version existence check. Use when re-triggering a failed publish job (pattern: force=true, create_release=false, publish=true)."
         required: false
         type: boolean
         default: false
@@ -27,6 +27,6 @@ jobs:
     uses: PowerShellOrg/.github/.github/workflows/powershell-release.yml@main
     with:
       version: ${{ inputs.version || '' }}
-      isPrerelease: ${{ inputs.isPrerelease || false }}
+      force: ${{ inputs.force || false }}
       dry_run: ${{ inputs.dry_run || false }}
     secrets: inherit

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,6 @@ jobs:
       version: ${{ inputs.version || '' }}
       force: ${{ inputs.force || false }}
       dry_run: ${{ inputs.dry_run || false }}
-      create_release: ${{ inputs.create_release != false }}
-      publish: ${{ inputs.publish != false }}
+      create_release: ${{ github.event_name != 'workflow_dispatch' || inputs.create_release }}
+      publish: ${{ github.event_name != 'workflow_dispatch' || inputs.publish }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Aligns with PowerShellOrg/.github#12.

- Removes `isPrerelease` dispatch input and `with:` pass-through — the reusable workflow now infers prerelease from `PSData.Prerelease` in the manifest automatically
- Adds `force` dispatch input to bypass the PSGallery existence check when re-triggering a failed job

## Re-trigger pattern

If `create_release` succeeds but `publish` fails (e.g. expired secret), re-trigger with:
`force=true, create_release=false, publish=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)