### PR TITLE
test: pin requested-version import for PSGalleryModule and PSResourceGet

### DIFF
--- a/Tests/PSGalleryModule.Type.Tests.ps1
+++ b/Tests/PSGalleryModule.Type.Tests.ps1
@@ -172,4 +172,36 @@ Describe 'PSGalleryModule script' {
             Should -Invoke -CommandName Install-Module -ModuleName PSDepend -Times 0
         }
     }
+
+    Context 'Multiple installed versions — requested version present but not the maximum' {
+        It 'Imports the requested version and skips Install when an older requested version is installed alongside a newer one' {
+            InModuleScope PSDepend {
+                Mock Get-Module {
+                    @(
+                        [PSCustomObject]@{ Name = 'TestModule'; Version = [version]'1.2.3' }
+                        [PSCustomObject]@{ Name = 'TestModule'; Version = [version]'2.0.0' }
+                    )
+                } -ParameterFilter { $ListAvailable }
+            }
+            $dep = New-PSDependFixture -DependencyName 'TestModule' -Version '1.2.3'
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -PSDependAction Test, Import
+            }
+            Should -Invoke -CommandName Import-PSDependModule -ModuleName PSDepend -Times 1 -Exactly `
+                -ParameterFilter { $Version.ToString() -eq '1.2.3' }
+            Should -Invoke -CommandName Install-Module -ModuleName PSDepend -Times 0
+        }
+    }
+
+    Context 'Repository = $null falls through to all registered repositories' {
+        It 'Skips repository validation and calls Install-Module without -Repository when Repository is null' {
+            $dep = New-PSDependFixture -DependencyName 'TestModule'
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -Repository $null
+            }
+            Should -Invoke -CommandName Get-PSRepository -ModuleName PSDepend -Times 0
+            Should -Invoke -CommandName Install-Module -ModuleName PSDepend -Times 1 -Exactly `
+                -ParameterFilter { -not $PSBoundParameters.ContainsKey('Repository') }
+        }
+    }
 }

--- a/Tests/PSResourceGet.Type.Tests.ps1
+++ b/Tests/PSResourceGet.Type.Tests.ps1
@@ -195,6 +195,24 @@ Describe 'PSResourceGet script' {
             $result | Should -Be $true
             Should -Invoke -CommandName Install-PSResource -ModuleName PSDepend -Times 0
         }
+
+        It 'Imports the requested version (not the maximum) when both are installed' {
+            InModuleScope PSDepend {
+                Mock Get-Module {
+                    @(
+                        [PSCustomObject]@{ Name = 'TestModule'; Version = [version]'1.2.3' }
+                        [PSCustomObject]@{ Name = 'TestModule'; Version = [version]'2.0.0' }
+                    )
+                } -ParameterFilter { $ListAvailable }
+            }
+            $dep = New-PSDependFixture -DependencyName 'TestModule' -DependencyType 'PSResourceGet' -Version '1.2.3'
+            InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+                & $ScriptPath -Dependency $Dep -PSDependAction Test, Import
+            }
+            Should -Invoke -CommandName Import-PSDependModule -ModuleName PSDepend -Times 1 -Exactly `
+                -ParameterFilter { $Version.ToString() -eq '1.2.3' }
+            Should -Invoke -CommandName Install-PSResource -ModuleName PSDepend -Times 0
+        }
     }
 
     Context 'Target as path uses Save-PSResource instead of Install-PSResource' {


### PR DESCRIPTION
## Summary

- **#44 PSGalleryModule**: new context "Multiple installed versions — requested version present but not the maximum" — asserts that `Import-PSDependModule` receives the explicitly requested version (1.2.3), not the maximum installed (2.0.0), and `Install-Module` is not called.
- **#44 PSResourceGet**: extends the existing "Multiple installed versions" context with a second `It` that invokes with `Test, Import` and asserts `Import-PSDependModule` receives version 1.2.3.
- **#55 PSGalleryModule**: new context "Repository = $null falls through to all registered repositories" — asserts that `Get-PSRepository` is skipped and `Install-Module` is called without a `-Repository` argument when `Repository` is null.

Closes #44, #55. Will also close #48, #69, #94 after merge (no new code needed for those; see individual issue comments).

## Test plan

- [x] `.\build.ps1 StageFiles; Invoke-Pester Tests/PSGalleryModule.Type.Tests.ps1, Tests/PSResourceGet.Type.Tests.ps1` — 29 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)