### PR TITLE
fix: InputObject hashtable no longer mutated by Get-Dependency (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Get-Dependency -InputObject` no longer mutates the caller's hashtable:
+  `PSDependOptions` is now preserved after the call, so a second invocation
+  with the same object still honors global options such as `Target` (#35).
+
 ## [0.4.1] - 2026-06-12
 
 ### Fixed

--- a/PSDepend/Public/Get-Dependency.ps1
+++ b/PSDepend/Public/Get-Dependency.ps1
@@ -437,7 +437,7 @@
     elseif ($PSCmdlet.ParameterSetName -eq 'Hashtable') {
         $DependencyFile = 'Hashtable'
         $ParsedDependencies = foreach ($InputDependency in $InputObject) {
-            $Dependencies = $InputDependency
+            $Dependencies = $InputDependency.Clone()
 
             Parse-Dependency -ParamSet $PSCmdlet.ParameterSetName
         }

--- a/Tests/PSDepend.Tests.ps1
+++ b/Tests/PSDepend.Tests.ps1
@@ -119,6 +119,26 @@ Describe "Get-Dependency PS$PSVersion" -Tag 'Unit' {
             $Dependencies | Should -BeNullOrEmpty
         }
 
+        It 'Does not mutate the caller''s InputObject — PSDependOptions key survives after Get-Dependency' {
+            $inputObj = @{
+                PSDependOptions = @{ Target = 'CurrentUser' }
+                Pester          = 'latest'
+            }
+            $null = Get-Dependency -InputObject $inputObj
+            $inputObj.ContainsKey('PSDependOptions') | Should -Be $True
+        }
+
+        It 'Does not mutate the caller''s InputObject — PSDependOptions honored on a second Get-Dependency call' {
+            $inputObj = @{
+                PSDependOptions = @{ Target = 'CurrentUser' }
+                Pester          = 'latest'
+            }
+            $null = Get-Dependency -InputObject $inputObj
+            $null = Get-Dependency -InputObject $inputObj
+            $inputObj.ContainsKey('PSDependOptions') | Should -Be $True
+            $inputObj.PSDependOptions.Target | Should -Be 'CurrentUser'
+        }
+
         It 'Parses -InputObject hashtable as PSGalleryModule by default' {
             $Dependencies = Get-Dependency -InputObject @{ Pester = 'latest' }
             $Dependencies.DependencyName | Should -Be 'Pester'

--- a/Tests/PSDepend.Tests.ps1
+++ b/Tests/PSDepend.Tests.ps1
@@ -134,9 +134,10 @@ Describe "Get-Dependency PS$PSVersion" -Tag 'Unit' {
                 Pester          = 'latest'
             }
             $null = Get-Dependency -InputObject $inputObj
-            $null = Get-Dependency -InputObject $inputObj
+            $deps2 = Get-Dependency -InputObject $inputObj
             $inputObj.ContainsKey('PSDependOptions') | Should -Be $True
             $inputObj.PSDependOptions.Target | Should -Be 'CurrentUser'
+            ($deps2 | Where-Object DependencyName -eq 'Pester').Target | Should -Be 'CurrentUser'
         }
 
         It 'Parses -InputObject hashtable as PSGalleryModule by default' {


### PR DESCRIPTION
## Summary

- `Get-Dependency -InputObject` now clones each element before passing it to `Parse-Dependency`, so `PSDependOptions` is no longer stripped from the caller's hashtable
- A second `Invoke-PSDepend` / `Get-Dependency` call with the same object now correctly honours global options (e.g. `Target`)
- Two regression tests added covering single and double invocation

## Root cause

`Get-Dependency.ps1:440` assigned `$Dependencies = $InputDependency` (a reference copy). `Parse-Dependency` then called `$Dependencies.Remove('PSDependOptions')`, mutating the original hashtable in the caller's scope.

**Fix:** `$Dependencies = $InputDependency.Clone()` — one-line shallow clone, sufficient because `Remove` only touches the top-level key and no other mutation sites exist.

## Test plan

- [x] `.\build.ps1 StageFiles` then `Invoke-Pester Tests\PSDepend.Tests.ps1 -Tag Unit` — all 22 tests pass
- [x] New tests: *"Does not mutate the caller's InputObject — PSDependOptions key survives after Get-Dependency"* and *"...honored on a second Get-Dependency call"*

Closes #35

Generated with [Claude Code](https://claude.com/claude-code)