### PR TITLE
fix: warn when Git target exists but is not a valid git repository (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FileDownload` is now supported on all platforms (`windows`, `core`, `macos`, `linux`); there was no Windows-only code blocking this (#98).
-- `FileDownload` relative `Target` paths are now rooted against `$PWD` before resolution, matching the intuitive expectation of callers (#49).
+- `FileDownload` is now supported on all platforms (`windows`, `core`,
+  `macos`, `linux`); there was no Windows-only code blocking this (#98).
+- `FileDownload` relative `Target` paths are now rooted against `$PWD`
+  before resolution, matching the intuitive expectation of callers (#49).
 
 ### Fixed
 
 - `Get-Dependency -InputObject` no longer mutates the caller's hashtable:
   `PSDependOptions` is now preserved after the call, so a second invocation
   with the same object still honors global options such as `Target` (#35).
-- `FileDownload` no longer misidentifies a directory-like `Target` (no file extension, or trailing slash) as a full file path when its parent happens to exist; the handler now uses a file-extension heuristic to distinguish file targets from container targets and creates the directory when it does not yet exist (#49).
+- `FileDownload` no longer misidentifies a directory-like `Target` (no
+  file extension, or trailing slash) as a full file path when its parent
+  happens to exist; the handler now uses a file-extension heuristic to
+  distinguish file targets from container targets and creates the directory
+  when it does not yet exist (#49).
+- `Git` handler no longer silently ignores a pre-existing directory at
+  the clone target that is not a valid git repository; it now emits a
+  `Write-Warning` so the user knows why the install was skipped (#86).
+
+### Tests
+
+- Added idempotency test: a second install run against an already-cloned
+  repo does not trigger a second `git clone` (#86).
+- Added non-git-directory test: confirms a warning is emitted and no
+  clone is attempted when the target path exists but is not a git repo (#86).
 
 ## [0.4.1] - 2026-06-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,13 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the clone target that is not a valid git repository; it now emits a
   `Write-Warning` so the user knows why the install was skipped (#86).
 
-### Tests
-
-- Added idempotency test: a second install run against an already-cloned
-  repo does not trigger a second `git clone` (#86).
-- Added non-git-directory test: confirms a warning is emitted and no
-  clone is attempted when the target path exists but is not a git repo (#86).
-
 ## [0.4.1] - 2026-06-12
 
 ### Fixed

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -134,6 +134,9 @@ if ($GottaTest) {
     Pop-Location
     if (-not $Branch) {
         Write-Warning "[$RepoPath] exists but does not appear to be a valid git repository. Skipping [$DependencyName]."
+        if ($PSDependAction -contains 'Test' -and $PSDependAction.count -eq 1) {
+            return $false
+        }
         $GottaInstall = $False
     }
     elseif ($Version -eq $Branch -or $Version -eq $Commit) {

--- a/PSDepend/PSDependScripts/Git.ps1
+++ b/PSDepend/PSDependScripts/Git.ps1
@@ -132,7 +132,11 @@ if ($GottaTest) {
     $Branch = Invoke-ExternalCommand git -Arguments (Write-Output rev-parse --abbrev-ref HEAD) -Passthru
     $Commit = Invoke-ExternalCommand git -Arguments (Write-Output rev-parse HEAD) -Passthru
     Pop-Location
-    if ($Version -eq $Branch -or $Version -eq $Commit) {
+    if (-not $Branch) {
+        Write-Warning "[$RepoPath] exists but does not appear to be a valid git repository. Skipping [$DependencyName]."
+        $GottaInstall = $False
+    }
+    elseif ($Version -eq $Branch -or $Version -eq $Commit) {
         Write-Verbose "[$RepoPath] exists and is already at version [$Version]"
         if ($PSDependAction -contains 'Test' -and $PSDependAction.count -eq 1) {
             return $true

--- a/Tests/Git.Type.Tests.ps1
+++ b/Tests/Git.Type.Tests.ps1
@@ -92,6 +92,9 @@ Describe 'Git script' {
         Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0 -ParameterFilter {
             $Arguments -contains 'clone'
         }
+        Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0 -ParameterFilter {
+            $Arguments -contains 'checkout'
+        }
     }
 
     It 'Emits a warning and skips install when the repo path exists but is not a git repository' {
@@ -103,7 +106,11 @@ Describe 'Git script' {
         InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
             # rev-parse returns nothing (non-git directory)
             Mock Invoke-ExternalCommand { }
-            { & $ScriptPath -Dependency $Dep } | Should -Not -Throw
+            Mock Write-Warning { }
+            & $ScriptPath -Dependency $Dep
+        }
+        Should -Invoke -CommandName Write-Warning -ModuleName PSDepend -Times 1 -ParameterFilter {
+            $Message -like '*does not appear to be a valid git repository*'
         }
         Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0 -ParameterFilter {
             $Arguments -contains 'clone'

--- a/Tests/Git.Type.Tests.ps1
+++ b/Tests/Git.Type.Tests.ps1
@@ -74,4 +74,39 @@ Describe 'Git script' {
         $result | Should -Be $false
         Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0
     }
+
+    It 'Does not clone again when repo already exists at the correct version (idempotency)' {
+        $targetDir = (New-Item 'TestDrive:/git-idempotent' -ItemType Directory -Force).FullName
+        # Pre-create the repo directory as if a prior run cloned it
+        $null = New-Item (Join-Path $targetDir 'repo') -ItemType Directory -Force
+        $dep = New-PSDependFixture -DependencyName 'https://example.com/user/repo.git' -DependencyType 'Git' -Version 'main' -Target $targetDir
+
+        InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+            # rev-parse returns the branch name matching Version
+            Mock Invoke-ExternalCommand {
+                if ($Arguments -contains '--abbrev-ref') { return 'main' }
+                if ($Arguments -notcontains 'clone' -and $Arguments -notcontains '--abbrev-ref') { return 'abc1234' }
+            }
+            & $ScriptPath -Dependency $Dep
+        }
+        Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0 -ParameterFilter {
+            $Arguments -contains 'clone'
+        }
+    }
+
+    It 'Emits a warning and skips install when the repo path exists but is not a git repository' {
+        $targetDir = (New-Item 'TestDrive:/git-nongit' -ItemType Directory -Force).FullName
+        # Pre-create the directory but leave it empty (not a git repo)
+        $null = New-Item (Join-Path $targetDir 'repo') -ItemType Directory -Force
+        $dep = New-PSDependFixture -DependencyName 'https://example.com/user/repo.git' -DependencyType 'Git' -Version 'main' -Target $targetDir
+
+        InModuleScope PSDepend -Parameters @{ Dep = $dep; ScriptPath = $script:ScriptPath } {
+            # rev-parse returns nothing (non-git directory)
+            Mock Invoke-ExternalCommand { }
+            { & $ScriptPath -Dependency $Dep } | Should -Not -Throw
+        }
+        Should -Invoke -CommandName Invoke-ExternalCommand -ModuleName PSDepend -Times 0 -ParameterFilter {
+            $Arguments -contains 'clone'
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Closes #86 (the nested `Repo/Repo` bug was confirmed non-reproducible on current code)
- Adds an explicit `Write-Warning` when `$RepoPath` exists but `git rev-parse` returns nothing, so users get a clear signal instead of a silent no-op with a misleading verbose message
- Two new Pester tests: idempotency (second run does not re-clone) and non-git-directory (warning emitted, no clone attempted)

## Test plan

- [x] `.\build.ps1 StageFiles` then `Invoke-Pester Tests/Git.Type.Tests.ps1` — all 5 tests pass
- [x] Manual repro attempt with a local bare repo: 3 consecutive installs produce no nesting

🤖 Generated with [Claude Code](https://claude.com/claude-code)