### PR TITLE
Switch SymVer to SemVer

### DIFF
--- a/PSDepend/Private/SemanticVersion.ps1
+++ b/PSDepend/Private/SemanticVersion.ps1
@@ -85,7 +85,7 @@ namespace System.Management.Automation
         public SemanticVersion(int major, int minor, int patch, string label)
             : this(major, minor, patch)
         {
-            // We presume the SymVer :
+            // We presume the SemVer :
             // 1) major.minor.patch-label
             // 2) 'label' starts with letter or digit.
             if (!string.IsNullOrEmpty(label))
@@ -238,7 +238,7 @@ namespace System.Management.Automation
 
 
         /// <summary>
-        /// PreReleaseLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// PreReleaseLabel position in the SemVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
         /// </summary>
         private string preReleaseLabel;
 
@@ -249,7 +249,7 @@ namespace System.Management.Automation
 
 
         /// <summary>
-        /// BuildLabel position in the SymVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+        /// BuildLabel position in the SemVer string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
         /// </summary>
         private string buildLabel;
 
@@ -318,7 +318,7 @@ namespace System.Management.Automation
             string preLabel = null;
             string buildLabel = null;
 
-            // We parse the SymVer 'version' string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
+            // We parse the SemVer 'version' string 'major.minor.patch-PreReleaseLabel+BuildLabel'.
             var dashIndex = version.IndexOf('-');
             var plusIndex = version.IndexOf('+');
 
@@ -474,7 +474,7 @@ namespace System.Management.Automation
 
         /// <summary>
         /// Implement <see cref="IComparable{T}.CompareTo"/>.
-        /// Meets SymVer 2.0 p.11 https://semver.org/
+        /// Meets SemVer 2.0 p.11 https://semver.org/
         /// </summary>
         public int CompareTo(SemanticVersion value)
         {
@@ -490,7 +490,7 @@ namespace System.Management.Automation
             if (Patch != value.Patch)
                 return Patch > value.Patch ? 1 : -1;
 
-            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            // SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return ComparePreLabel(this.PreReleaseLabel, value.PreReleaseLabel);
         }
 
@@ -507,7 +507,7 @@ namespace System.Management.Automation
         /// </summary>
         public bool Equals(SemanticVersion other)
         {
-            // SymVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
+            // SemVer 2.0 standard requires to ignore 'BuildLabel' (Build metadata).
             return other != null &&
                    (Major == other.Major) && (Minor == other.Minor) && (Patch == other.Patch) &&
                    string.Equals(PreReleaseLabel, other.PreReleaseLabel, StringComparison.Ordinal);
@@ -576,7 +576,7 @@ namespace System.Management.Automation
 
         private static int ComparePreLabel(string preLabel1, string preLabel2)
         {
-            // Symver 2.0 standard p.9
+            // SemVer 2.0 standard p.9
             // Pre-release versions have a lower precedence than the associated normal version.
             // Comparing each dot separated identifier from left to right
             // until a difference is found as follows:

--- a/PSDepend/Private/SemanticVersion.ps1
+++ b/PSDepend/Private/SemanticVersion.ps1
@@ -85,7 +85,7 @@ namespace System.Management.Automation
         public SemanticVersion(int major, int minor, int patch, string label)
             : this(major, minor, patch)
         {
-            // We presume the SemVer :
+            // We presume the SemVer:
             // 1) major.minor.patch-label
             // 2) 'label' starts with letter or digit.
             if (!string.IsNullOrEmpty(label))


### PR DESCRIPTION
Renames `SymVer` to the correct `SemVer` (Semantic Versioning) in `PSDepend/Private/SemanticVersion.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)